### PR TITLE
display and allow for editing of empty fields  

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "uow_frontend",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -13,15 +13,6 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link href="https://unpkg.com/react-image-crop/dist/ReactCrop.css" rel="stylesheet" />
     <script src="https://unpkg.com/react-image-crop/dist/index.umd.cjs"></script>
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>UOW</title>
     <style>
       body {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "UOW UI",
+  "name": "Undocumented Orphaned Wells UI",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/RecordsTable/RecordsTable.js
+++ b/src/components/RecordsTable/RecordsTable.js
@@ -76,7 +76,7 @@ export default function RecordsTable(props) {
     try {
       for (let key of Object.keys(attributes)) {
         let attr = attributes[key]
-        confidences.push(attr.confidence)
+        if (attr.confidence) confidences.push(attr.confidence)
       }
       return formatConfidence(average(confidences))
     } catch (e) {
@@ -89,7 +89,7 @@ export default function RecordsTable(props) {
     let lowestConfidence = 1
     for (let key of Object.keys(attributes)) {
       let attr = attributes[key]
-      if (attr.confidence < lowestConfidence) {
+      if (attr.confidence && attr.confidence < lowestConfidence) {
         lowestConfidence = attr.confidence
       }
     }


### PR DESCRIPTION
- To handle unfound attributes with null confidence, check for the existence of a confidence before calculating average, lowest