### PR TITLE
Row highlighting

### DIFF
--- a/.github/workflows/deploy-isgs.yml
+++ b/.github/workflows/deploy-isgs.yml
@@ -1,4 +1,4 @@
-name: Deploy Frontend
+name: Deploy ISGS Frontend
 
 on:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Frontend
+name: Deploy Staging Frontend
 
 on:
   push:

--- a/src/assets/helperFunctions.js
+++ b/src/assets/helperFunctions.js
@@ -1,5 +1,5 @@
 import { refreshAuth, revokeToken } from "../services/app.service"
-import { useEffect } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 export const formatDate = (timestamp) => {
   if (timestamp !== null) {
@@ -45,6 +45,24 @@ export const useKeyDown = (callback, keys) => {
       document.removeEventListener('keydown', onKeyDown);
     };
   }, [onKeyDown]);
+};
+
+export const useOutsideClick = (callback) => {
+  const ref = useRef();
+
+  useEffect(() => {
+    const handleClick = (event) => {
+      callback();
+    };
+
+    document.addEventListener('click', handleClick);
+
+    return () => {
+      document.removeEventListener('click', handleClick);
+    };
+  }, []);
+
+  return ref;
 };
 
 export const logout = () => {

--- a/src/components/DocumentContainer/DocumentContainer.js
+++ b/src/components/DocumentContainer/DocumentContainer.js
@@ -109,7 +109,7 @@ export default function DocumentContainer(props) {
     }
 
     const handleClickField = (key, normalized_vertices, isSubattribute, topLevelAttribute) => {
-        if(key === displayKey) {
+        if(key === displayKey || !key) {
             setDisplayPoints(null)
             setDisplayKey(null)
             setDisplayKeyIndex(null)

--- a/src/components/RecordAttributesTable/RecordAttributesTable.js
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableRow, TableContainer } from '@mui/material';
 import { Box, TextField, Collapse, Typography, IconButton } from '@mui/material';
-import { formatConfidence } from '../../assets/helperFunctions';
+import { formatConfidence, useKeyDown } from '../../assets/helperFunctions';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import EditIcon from '@mui/icons-material/Edit';
@@ -74,6 +74,13 @@ function AttributeRow(props) {
     const [ editMode, setEditMode ] = useState(false)
     const [ openSubtable, setOpenSubtable ] = useState(false)
 
+    useKeyDown(() => {
+        if (k === displayKey) {
+            if (editMode) handleUpdateRecord()
+            setEditMode(!editMode)
+        }
+    }, ["Enter"])
+
     useEffect(() => {
         if (forceOpenSubtable === k) setOpenSubtable(true)
     }, [forceOpenSubtable])
@@ -83,17 +90,17 @@ function AttributeRow(props) {
     }
 
     const handleKeyDown = (e) => {
-        if (e.key === "Enter") {
-            e.preventDefault();
-            setEditMode(false)
-            handleUpdateRecord()
-        } 
-        else if (e.key === "ArrowLeft") {
+        if (e.key === "ArrowLeft") {
             e.stopPropagation();
         }
         else if (e.key === "ArrowRight") {
             e.stopPropagation();
         }
+    }
+
+    const handleClickEditIcon = (e) => {
+        e.stopPropagation()
+        handleDoubleClick()
     }
 
     return (
@@ -121,9 +128,10 @@ function AttributeRow(props) {
                 <TableCell></TableCell> 
                 
                 :
-                <TableCell onDoubleClick={handleDoubleClick} onKeyDown={handleKeyDown} onClick={(e) => e.stopPropagation()}>
+                <TableCell onKeyDown={handleKeyDown}>
                     {editMode ? 
                         <TextField 
+                            onClick={(e) => e.stopPropagation()}
                             autoFocus
                             name={k}
                             size="small"
@@ -135,7 +143,7 @@ function AttributeRow(props) {
                         <span>
                             {v.value}&nbsp;
                             {k === displayKey && 
-                                <IconButton sx={styles.rowIconButton} onClick={handleDoubleClick}>
+                                <IconButton sx={styles.rowIconButton} onClick={handleClickEditIcon}>
                                     <EditIcon sx={styles.rowIcon}/>
                                 </IconButton>
                             }
@@ -214,17 +222,19 @@ function SubattributeRow(props) {
     const { k, v, handleClickField, handleChangeValue, topLevelAttribute, fullscreen, displayKey, attributesList, displayKeyIndex, handleUpdateRecord } = props
     const [ editMode, setEditMode ] = useState(false)
 
+    useKeyDown(() => {
+        if (k === displayKey && topLevelAttribute === attributesList[displayKeyIndex].topLevelAttribute) {
+            if (editMode) handleUpdateRecord()
+            setEditMode(!editMode)
+        }
+    }, ["Enter"])
+
     const handleDoubleClick = () => {
         setEditMode(true)
     }
 
     const handleKeyDown = (e) => {
-        if (e.key === "Enter") {
-            e.preventDefault();
-            setEditMode(false)
-            handleUpdateRecord()
-        } 
-        else if (e.key === "ArrowLeft") {
+        if (e.key === "ArrowLeft") {
             e.stopPropagation();
         }
         else if (e.key === "ArrowRight") {
@@ -234,6 +244,11 @@ function SubattributeRow(props) {
 
     const handleUpdateValue = (event) => {
         handleChangeValue(event, true, topLevelAttribute)
+    }
+
+    const handleClickEditIcon = (e) => {
+        e.stopPropagation()
+        handleDoubleClick()
     }
 
     return (
@@ -250,9 +265,10 @@ function SubattributeRow(props) {
                 {k}
             </span>
             </TableCell>
-            <TableCell onKeyDown={handleKeyDown} onClick={(e) => e.stopPropagation()}>
+            <TableCell onKeyDown={handleKeyDown} >
                 {editMode ? 
                     <TextField 
+                        onClick={(e) => e.stopPropagation()}
                         autoFocus
                         name={k}
                         size="small" 
@@ -261,10 +277,10 @@ function SubattributeRow(props) {
                         onFocus={(event) => event.target.select()}
                     />
                     :
-                    <span onDoubleClick={handleDoubleClick}>
+                    <span>
                     {v.value}&nbsp;
                         {(k === displayKey && topLevelAttribute === attributesList[displayKeyIndex].topLevelAttribute) && 
-                            <IconButton sx={styles.rowIconButton} onClick={handleDoubleClick}>
+                            <IconButton sx={styles.rowIconButton} onClick={handleClickEditIcon}>
                                 <EditIcon sx={styles.rowIcon}/>
                             </IconButton>
                         }

--- a/src/components/RecordAttributesTable/RecordAttributesTable.js
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.js
@@ -36,6 +36,10 @@ const styles = {
 
 export default function AttributesTable(props) {
     const { attributes, handleClickField, handleChangeValue, fullscreen, displayKey, forceOpenSubtable, attributesList, displayKeyIndex, handleUpdateRecord } = props
+    const handleClickOutside = () => {
+        handleClickField()
+    }
+    let ref = useOutsideClick(handleClickOutside);
 
     return (
         <TableContainer id="table-container" sx={styles.fieldsTable}>
@@ -47,7 +51,7 @@ export default function AttributesTable(props) {
                         <TableCell sx={styles.headerRow}>Confidence</TableCell>
                     </TableRow>
                 </TableHead>
-                <TableBody>
+                <TableBody ref={ref}>
                     {Object.entries(attributes).map(([k, v]) => (
                         <AttributeRow 
                             key={k}
@@ -79,19 +83,6 @@ function AttributeRow(props) {
             if (editMode) finishEditing()
         }
     },[displayKey])
-
-    const handleClickOutside = (tempEditMode) => {
-        if (displayKey === "AS_DRILLED_LATITUDE")
-        {
-            console.log("handle click outside")
-            console.log(tempEditMode)
-            console.log(editMode)
-            if (editMode)  {
-                finishEditing()
-            }
-        }
-        
-    }
 
     const handleClickInside = (e) => {
         e.stopPropagation()
@@ -131,8 +122,6 @@ function AttributeRow(props) {
         handleUpdateRecord()
         setEditMode(false)
     }
-
-    // const ref = useOutsideClick(() => handleClickOutside(editMode));
 
     return (
     <>
@@ -257,7 +246,7 @@ function SubattributeRow(props) {
         if (!(k === displayKey && topLevelAttribute === attributesList[displayKeyIndex].topLevelAttribute)) {
             if (editMode) finishEditing()
         }
-    },[k, topLevelAttribute])
+    },[displayKey, topLevelAttribute])
 
     useKeyDown(() => {
         if (k === displayKey && topLevelAttribute === attributesList[displayKeyIndex].topLevelAttribute) {
@@ -265,12 +254,6 @@ function SubattributeRow(props) {
             else setEditMode(true)
         }
     }, ["Enter"])
-
-    const handleClickOutside = () => {
-        if (editMode)  {
-            finishEditing()
-        }
-    }
 
     const handleClickInside = (e) => {
         e.stopPropagation()
@@ -304,11 +287,8 @@ function SubattributeRow(props) {
         setEditMode(false)
     }
 
-    // const ref = useOutsideClick(handleClickOutside);
-
     return (
         <TableRow 
-            // ref={ref}
             key={k} 
             id={`${topLevelAttribute}::${k}`} 
             sx={(k === displayKey && topLevelAttribute === attributesList[displayKeyIndex].topLevelAttribute) ? {backgroundColor: "#EDEDED"} : {}}

--- a/src/components/RecordAttributesTable/RecordAttributesTable.js
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableRow, TableContainer } from '@mui/material';
 import { Box, TextField, Collapse, Typography, IconButton } from '@mui/material';
-import { formatConfidence, useKeyDown } from '../../assets/helperFunctions';
+import { formatConfidence, useKeyDown, useOutsideClick } from '../../assets/helperFunctions';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import EditIcon from '@mui/icons-material/Edit';
@@ -74,10 +74,34 @@ function AttributeRow(props) {
     const [ editMode, setEditMode ] = useState(false)
     const [ openSubtable, setOpenSubtable ] = useState(false)
 
+    useEffect(() => {
+        if (k !== displayKey) {
+            if (editMode) finishEditing()
+        }
+    },[displayKey])
+
+    const handleClickOutside = (tempEditMode) => {
+        if (displayKey === "AS_DRILLED_LATITUDE")
+        {
+            console.log("handle click outside")
+            console.log(tempEditMode)
+            console.log(editMode)
+            if (editMode)  {
+                finishEditing()
+            }
+        }
+        
+    }
+
+    const handleClickInside = (e) => {
+        e.stopPropagation()
+        handleClickField(k, v.normalized_vertices)
+    }
+
     useKeyDown(() => {
         if (k === displayKey) {
-            if (editMode) handleUpdateRecord()
-            setEditMode(!editMode)
+            if (editMode) finishEditing()
+            else setEditMode(true)
         }
     }, ["Enter"])
 
@@ -103,9 +127,16 @@ function AttributeRow(props) {
         handleDoubleClick()
     }
 
+    const finishEditing = () => {
+        handleUpdateRecord()
+        setEditMode(false)
+    }
+
+    // const ref = useOutsideClick(() => handleClickOutside(editMode));
+
     return (
     <>
-        <TableRow id={k} sx={k === displayKey ? {backgroundColor: "#EDEDED"} : {}} onClick={() => handleClickField(k, v.normalized_vertices)}>
+        <TableRow id={k} sx={k === displayKey ? {backgroundColor: "#EDEDED"} : {}} onClick={handleClickInside}>
             <TableCell sx={styles.fieldKey}>
                 
                 <span>
@@ -222,12 +253,29 @@ function SubattributeRow(props) {
     const { k, v, handleClickField, handleChangeValue, topLevelAttribute, fullscreen, displayKey, attributesList, displayKeyIndex, handleUpdateRecord } = props
     const [ editMode, setEditMode ] = useState(false)
 
+    useEffect(() => {
+        if (!(k === displayKey && topLevelAttribute === attributesList[displayKeyIndex].topLevelAttribute)) {
+            if (editMode) finishEditing()
+        }
+    },[k, topLevelAttribute])
+
     useKeyDown(() => {
         if (k === displayKey && topLevelAttribute === attributesList[displayKeyIndex].topLevelAttribute) {
-            if (editMode) handleUpdateRecord()
-            setEditMode(!editMode)
+            if (editMode) finishEditing()
+            else setEditMode(true)
         }
     }, ["Enter"])
+
+    const handleClickOutside = () => {
+        if (editMode)  {
+            finishEditing()
+        }
+    }
+
+    const handleClickInside = (e) => {
+        e.stopPropagation()
+        handleClickField(k, v.normalized_vertices, true, topLevelAttribute)
+    }
 
     const handleDoubleClick = () => {
         setEditMode(true)
@@ -251,12 +299,20 @@ function SubattributeRow(props) {
         handleDoubleClick()
     }
 
+    const finishEditing = () => {
+        handleUpdateRecord()
+        setEditMode(false)
+    }
+
+    // const ref = useOutsideClick(handleClickOutside);
+
     return (
         <TableRow 
+            // ref={ref}
             key={k} 
             id={`${topLevelAttribute}::${k}`} 
             sx={(k === displayKey && topLevelAttribute === attributesList[displayKeyIndex].topLevelAttribute) ? {backgroundColor: "#EDEDED"} : {}}
-            onClick={() => handleClickField(k, v.normalized_vertices, true, topLevelAttribute)}
+            onClick={handleClickInside}
         >
             <TableCell sx={styles.fieldKey} >
             <span 


### PR DESCRIPTION
- addresses issue #54 
- Highlighted section in image updates on click anywhere in row
- remove double clicking on value field to open edit box
   - causes interference with single click, no native way to differentiate 2 single clicks from a double click
- Remove row highlight, image highlight and close edit box if clicked anywhere outside, or on other value field