### PR TITLE
Keyboard shortcuts

### DIFF
--- a/src/assets/helperFunctions.js
+++ b/src/assets/helperFunctions.js
@@ -31,12 +31,33 @@ export const formatConfidence = (value) => {
   return `${percentageValue} %`
 }
 
-export const useKeyDown = (callback, keys) => {
+export const useKeyDown = (key, singleKeyCallback, shiftKeyCallback, controlKeyCallback, shiftAndControlKeyCallback) => {
+  /*
+    hook for adding a callback function on a key down
+    has options for:
+      1. singleKeyCallback: the key by itself
+      2. shiftKeyCallback: shift + the key
+      3. controlKeyCallback: ctrl/cmd + the key
+      4. shiftAndControlKeyCallback: shift + ctrl/cmd + the key
+  */
   const onKeyDown = (event) => {
-    const wasAnyKeyPressed = keys.some((key) => event.key === key);
-    if (wasAnyKeyPressed) {
+    // event.metaKey - pressed Command key on Macs
+    // event.ctrlKey - pressed Control key on Linux or Windows
+    const wasKeyPressed = event.key === key;
+    if (wasKeyPressed) {
       event.preventDefault();
-      callback();
+      if ((event.metaKey || event.ctrlKey) && event.shiftKey && shiftAndControlKeyCallback) {
+        shiftAndControlKeyCallback()
+      }
+      else if ((event.metaKey || event.ctrlKey) && controlKeyCallback) {
+        controlKeyCallback()
+      }
+      else if (event.shiftKey && shiftKeyCallback) {
+        shiftKeyCallback()
+      }
+      else if (singleKeyCallback) {
+        singleKeyCallback()
+      }
     }
   };
   useEffect(() => {

--- a/src/components/DocumentContainer/DocumentContainer.js
+++ b/src/components/DocumentContainer/DocumentContainer.js
@@ -51,12 +51,6 @@ export default function DocumentContainer(props) {
         setDisplayKeyIndex(null)
     },[params.id])
 
-    
-
-    useKeyDown(() => {
-        tabCallback();
-    }, ["Tab"]);
-
     const tabCallback = () => {
         let tempIndex
         if (displayKeyIndex === null || displayKeyIndex === attributesList.length - 1) {
@@ -107,6 +101,61 @@ export default function DocumentContainer(props) {
         }
         
     }
+
+    const shiftTabCallback = () => {
+        let tempIndex
+        if (displayKeyIndex === null || displayKeyIndex === 0) {
+            tempIndex = attributesList.length - 1
+        } else {
+            tempIndex = displayKeyIndex -1
+        }
+        let keepGoing = true
+        let i = 0;
+        while (keepGoing && i < 200) {
+            i+=1
+            let tempKey = attributesList[tempIndex].key
+            let tempVertices = attributesList[tempIndex].normalized_vertices
+            if(tempVertices !== null && tempVertices !== undefined) {
+                let isSubattribute = attributesList[tempIndex].isSubattribute
+                let topLevelAttribute = attributesList[tempIndex].topLevelAttribute
+                handleClickField(tempKey, tempVertices, isSubattribute, topLevelAttribute)
+                keepGoing = false 
+                let elementId
+                if (isSubattribute) {
+                    setForceOpenSubtable(topLevelAttribute)
+                    elementId = `${topLevelAttribute}::${tempKey}`
+                } 
+                else elementId = tempKey
+                let element = document.getElementById(elementId)
+                let waitTime = 0
+                let containerElement = document.getElementById("table-container")
+                if (element) {
+                    if (isSubattribute) {
+                        setTimeout(function() {
+                            element.scrollIntoView({ behavior: "smooth", block: "end", inline: "nearest" })
+                        }, waitTime)
+                    }
+                    else scrollIntoView(element, containerElement)
+                } else // element likely has not rendered yet. wait 250 milliseconds then try again
+                {
+                    waitTime = 250
+                    setTimeout(function() {
+                        element = document.getElementById(elementId)
+                        if (element) element.scrollIntoView({ behavior: "smooth", block: "end", inline: "nearest" })
+                    }, waitTime)
+                }
+            }
+            else {
+                tempIndex-=1
+                if (tempIndex === 0) tempIndex = attributesList.length -1
+            }
+        }
+        
+    }
+
+    useKeyDown("Tab", tabCallback, shiftTabCallback, null, null);
+    useKeyDown("ArrowUp", shiftTabCallback, null, null, null);
+    useKeyDown("ArrowDown", tabCallback, null, null, null);
 
     const handleClickField = (key, normalized_vertices, isSubattribute, topLevelAttribute) => {
         if(key === displayKey || !key) {

--- a/src/components/RecordAttributesTable/RecordAttributesTable.js
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.js
@@ -89,12 +89,18 @@ function AttributeRow(props) {
         handleClickField(k, v.normalized_vertices)
     }
 
-    useKeyDown(() => {
+    useKeyDown("Enter", () => {
         if (k === displayKey) {
             if (editMode) finishEditing()
             else setEditMode(true)
         }
-    }, ["Enter"])
+    }, null, null, null)
+
+    useKeyDown("Escape", () => {
+        if (k === displayKey) {
+            if (editMode) finishEditing()
+        }
+    }, null, null, null)
 
     useEffect(() => {
         if (forceOpenSubtable === k) setOpenSubtable(true)
@@ -248,12 +254,18 @@ function SubattributeRow(props) {
         }
     },[displayKey, topLevelAttribute])
 
-    useKeyDown(() => {
+    useKeyDown("Enter", () => {
         if (k === displayKey && topLevelAttribute === attributesList[displayKeyIndex].topLevelAttribute) {
             if (editMode) finishEditing()
             else setEditMode(true)
         }
-    }, ["Enter"])
+    }, null, null, null)
+
+    useKeyDown("Escape", () => {
+        if (k === displayKey && topLevelAttribute === attributesList[displayKeyIndex].topLevelAttribute) {
+            if (editMode) finishEditing()
+        }
+    }, null, null, null)
 
     const handleClickInside = (e) => {
         e.stopPropagation()

--- a/src/views/RecordPage/RecordPage.js
+++ b/src/views/RecordPage/RecordPage.js
@@ -212,13 +212,9 @@ export default function Record() {
         )
     }
 
-    useKeyDown(() => {
-        handleClickPrevious();
-    }, ["ArrowLeft"]);
+    useKeyDown("ArrowLeft", null, null, handleClickPrevious, null);
 
-    useKeyDown(() => {
-        handleClickMarkReviewed();
-    }, ["ArrowRight"]);
+    useKeyDown("ArrowRight", null, null, handleClickNext, handleClickMarkReviewed);
 
     const handleSuccessNavigateRecord = (data) => {
         navigate("/record/"+data._id, {replace: true})


### PR DESCRIPTION
addresses issue #73 
- update useKeyDown hook to handle different combinations of keyDown
  - add options for solo key, shift+key, ctrl/cmd+key, and shift+ctrl/cmd+key, 
- add useKeyDowns for shift+tab, arrow up and down, ctrl+left, ctrl+shift+right