### PR TITLE
only update review status upon response if it is present

### DIFF
--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -118,7 +118,8 @@ const Record = () => {
     const handleSuccessfulAttributeUpdate = (data: any) => {
         let tempRecordData = { ...recordData } as RecordData;
         tempRecordData["attributesList"] = data["attributesList"]
-        tempRecordData["review_status"] = data["review_status"]
+        if (data["review_status"]) tempRecordData["review_status"] = data["review_status"]
+        
         setRecordData(tempRecordData);
     }
 


### PR DESCRIPTION
review status currently disappears because we are trying to set the review status upon the response even if it is not part of the response