### PR TITLE
when editing a field, only update record if the value has actually been edited

### DIFF
--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -128,6 +128,7 @@ const AttributeRow = (props: AttributeRowProps) => {
     const [ editMode, setEditMode ] = useState(false);
     const [ openSubtable, setOpenSubtable ] = useState(false);
     const [ isSelected, setIsSelected ] = useState(false);
+    const [ lastSavedValue, setLastSavedValue ] = useState(v.value)
 
     useEffect(() => {
         if (idx === displayKeyIndex && (displayKeySubattributeIndex === null || displayKeySubattributeIndex === undefined)) setIsSelected(true);
@@ -151,7 +152,18 @@ const AttributeRow = (props: AttributeRowProps) => {
 
     useKeyDown("Escape", () => {
         if (isSelected) {
-            if (editMode) finishEditing();
+            if (editMode) {
+                // reset to last saved value
+                if (v.value !== lastSavedValue) {
+                    let fakeEvent = {
+                        target: {
+                            value: lastSavedValue
+                        }
+                    } as React.ChangeEvent<HTMLInputElement>
+                    handleChangeValue(fakeEvent, idx)
+                }
+                setEditMode(false);
+            }
         }
     }, undefined, undefined, undefined);
 
@@ -183,7 +195,10 @@ const AttributeRow = (props: AttributeRowProps) => {
     }
 
     const finishEditing = () => {
-        if (v.edited) handleUpdateRecord();
+        if (v.value !== lastSavedValue) {
+            handleUpdateRecord();
+            setLastSavedValue(v.value)
+        }
         setEditMode(false);
     }
 
@@ -380,6 +395,7 @@ const SubattributeRow = (props: SubattributeRowProps) => {
 
     const [ editMode, setEditMode ] = useState(false);
     const [ isSelected, setIsSelected ] = useState(false);
+    const [ lastSavedValue, setLastSavedValue ] = useState(v.value)
 
     useEffect(() => {
         if (displayKeyIndex === topLevelIdx && idx === displayKeySubattributeIndex) {
@@ -399,7 +415,18 @@ const SubattributeRow = (props: SubattributeRowProps) => {
 
     useKeyDown("Escape", () => {
         if (isSelected) {
-            if (editMode) finishEditing();
+            if (editMode) {
+                // reset to last saved value
+                if (v.value !== lastSavedValue) {
+                    let fakeEvent = {
+                        target: {
+                            value: lastSavedValue
+                        }
+                    } as React.ChangeEvent<HTMLInputElement>
+                    handleUpdateValue(fakeEvent)
+                }
+                setEditMode(false);
+            }
         }
     }, undefined, undefined, undefined);
 
@@ -437,7 +464,10 @@ const SubattributeRow = (props: SubattributeRowProps) => {
     }
 
     const finishEditing = () => {
-        if (v.edited) handleUpdateRecord();
+        if (v.value !== lastSavedValue) {
+            handleUpdateRecord();
+            setLastSavedValue(v.value)
+        }
         setEditMode(false);
     }
 

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -183,7 +183,7 @@ const AttributeRow = (props: AttributeRowProps) => {
     }
 
     const finishEditing = () => {
-        handleUpdateRecord();
+        if (v.edited) handleUpdateRecord();
         setEditMode(false);
     }
 
@@ -437,7 +437,7 @@ const SubattributeRow = (props: SubattributeRowProps) => {
     }
 
     const finishEditing = () => {
-        handleUpdateRecord();
+        if (v.edited) handleUpdateRecord();
         setEditMode(false);
     }
 


### PR DESCRIPTION
- addresses #165 
- also addresses escape key down. this will revert to last saved value instead of saving entered value