### PR TITLE
Fix bug that occurs when replying to the first note in notes dialog

### DIFF
--- a/src/components/RecordNotesDialog/RecordNotesDialog.tsx
+++ b/src/components/RecordNotesDialog/RecordNotesDialog.tsx
@@ -163,7 +163,7 @@ const RecordNotesDialog = ({ record_id, open, onClose }: RecordNotesDialogProps)
         if (text) data['text'] = text
         if (isReply)  {
             data['isReply'] = true
-            data['replyToIndex'] = replyToIdx || -1
+            if (replyToIdx !== undefined) data['replyToIndex'] = replyToIdx
         }
         callAPI(
             updateRecord,


### PR DESCRIPTION
#224 
- bug only occurred when responding to first comment
- check for undefined, not false (0 was false)