### PR TITLE
Show cleaned fields, raw fields, cleaning errors

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const test_record_group_name = "cypress test record group"
+const test_record_group_name = "Illinois Test Project"
 describe('End to end testing', () => {
   beforeEach(() => {
     cy.loginByGoogleApi()
@@ -144,7 +144,7 @@ describe('End to end testing', () => {
 
   it('tests edit field, review status updates, mark as unreviewed', () => {
     // click on record
-    cy.visit('/#/record/6699518f8107c59f0b6c8c11');
+    cy.visit('/#/record/665647e58294448787521760');
     cy.wait(2000)
     cy.screenshot('navigated to record cypress test record')
 
@@ -152,7 +152,7 @@ describe('End to end testing', () => {
     cy.get('#fullscreen-table-button').click()
 
     // click on field
-    let field_name = "Dry_Hole"
+    let field_name = "ACIDIZED"
     cy.get('#'+field_name+'_confidence').contains(/not found/i)
     cy.findByText(field_name).click()
     cy.screenshot('clicked on '+field_name)
@@ -191,7 +191,7 @@ describe('End to end testing', () => {
   })
 
   it('tests export data', () => {
-    cy.visit('/#/record_group/6699515b8107c59f0b6c8c0e');
+    cy.visit('/#/record_group/6656476a448c4d1812645c07');
     cy.wait(1000)
     cy.screenshot('navigated to project test list')
 

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const test_record_group_name = "Illinois Test Project"
+const test_project_name = "ISGS Project"
 describe('End to end testing', () => {
   beforeEach(() => {
     cy.loginByGoogleApi()
@@ -22,12 +23,12 @@ describe('End to end testing', () => {
 
     // navigate to project page
     cy.findByRole('rowheader', {
-      name: /test project/i
+      name: test_project_name
     }).click()
 
     // test that project page loaded correctly
     cy.findByRole('button', {
-      name: /test project/i
+      name: test_project_name
     }).should('be.visible')
     cy.findByRole('columnheader', {
       name: /record group name/i

--- a/src/assets/styles.ts
+++ b/src/assets/styles.ts
@@ -1,4 +1,4 @@
-const ERROR_TEXT_COLOR = '#B33E3b'
+export const ERROR_TEXT_COLOR = '#B33E3b'
 
 export const styles = {
   headerRow: {
@@ -95,7 +95,7 @@ export const styles = {
             borderColor: 'black'
         },
     },
-},
+  },
 }
 
 export const HeaderStyles = {

--- a/src/assets/styles.ts
+++ b/src/assets/styles.ts
@@ -294,9 +294,22 @@ export const DocumentContainerStyles = {
       backgroundColor: "white",
   },
   containerActions: {
+    left: {
+      display: 'flex',
+      justifyContent: 'flex-start',
+      marginleft: '20px',
+    },
+    right: {
       display: 'flex',
       justifyContent: 'flex-end',
       marginRight: '10px',
+    },
+    both: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      paddingX: 4,
+    }
+      
   },
   outerBox: {
       paddingBottom: "45px"

--- a/src/assets/styles.ts
+++ b/src/assets/styles.ts
@@ -54,7 +54,41 @@ export const styles = {
   unflaggedConfidence: {
       padding: 0,
       margin: 0,
-  }
+  },
+  errorParagraph: {
+    margin: 8,
+  },
+  errorText: {
+    color: '#B33E3B',
+    fontSize: '14px',
+    fontWeight: 'bold'
+  },
+  errorSpan: {
+    backgroundColor: '#FECDD3',
+    borderRadius: 4,
+    border: '2px solid #B33E3B'
+  },
+  noErrorParagraph: {
+    margin:0
+  },
+  errorTextField: {
+    '& .MuiOutlinedInput-root': {
+        // Default border
+        '& fieldset': {
+            border: '0px'
+        },
+        // On hover
+        '&:hover fieldset': {
+            borderWidth: '1.5px',
+            borderColor: 'black'
+        },
+        // On focus
+        '&.Mui-focused fieldset': {
+            borderWidth: '2px',
+            borderColor: 'black'
+        },
+    },
+},
 }
 
 export const HeaderStyles = {

--- a/src/assets/styles.ts
+++ b/src/assets/styles.ts
@@ -1,3 +1,5 @@
+const ERROR_TEXT_COLOR = '#B33E3b'
+
 export const styles = {
   headerRow: {
     fontWeight: "bold"
@@ -59,17 +61,22 @@ export const styles = {
     margin: 8,
   },
   errorText: {
-    color: '#B33E3B',
+    color: ERROR_TEXT_COLOR,
     fontSize: '14px',
     fontWeight: 'bold'
   },
   errorSpan: {
     backgroundColor: '#FECDD3',
     borderRadius: 4,
-    border: '2px solid #B33E3B'
+    border: '2px solid '+ERROR_TEXT_COLOR
   },
   noErrorParagraph: {
     margin:0
+  },
+  errorInfoIcon: {
+    fontSize: '12px',
+    padding: '2px',
+    color: ERROR_TEXT_COLOR
   },
   errorTextField: {
     '& .MuiOutlinedInput-root': {

--- a/src/assets/util.ts
+++ b/src/assets/util.ts
@@ -165,7 +165,8 @@ export const formatDate = (timestamp: number | null): string | null => {
   } else return String(timestamp);
 }
 
-export function formatDateTime(timestamp: number): string {
+export function formatDateTime(timestamp?: number): string {
+  if (timestamp === undefined) return 'unknown'
   if (timestamp === -1) return 'unknown'
   if (timestamp > 1e12) {
     timestamp = Math.floor(timestamp / 1000); // Convert milliseconds to seconds

--- a/src/assets/util.ts
+++ b/src/assets/util.ts
@@ -208,6 +208,13 @@ export const formatConfidence = (value: number | null): string => {
   return `${percentageValue} %`;
 }
 
+export const formatAttributeValue = (value: string | number | boolean | null): string | number => {
+  if (value === null) return "";
+  else if (value === true) return 'true'
+  else if (value === false) return 'false'
+  else return value
+}
+
 export const useKeyDown = (
   key: string, 
   singleKeyCallback?: () => void, 

--- a/src/components/DocumentContainer/DocumentContainer.tsx
+++ b/src/components/DocumentContainer/DocumentContainer.tsx
@@ -22,6 +22,7 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
     const [forceOpenSubtable, setForceOpenSubtable] = useState<number | null>(null);
     const [imageHeight, setImageHeight] = useState(0);
     const [ showRawValues, setShowRawValues ] = useState(false)
+    const [ autoCleanFields, setAutoCleanFields ] = useState(true)
     const imageDivStyle = {
         width: width,
         height: height,
@@ -287,16 +288,21 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
                     fullscreen !== "image" && 
                     <Grid item xs={gridWidths[2]}>
                         <Box sx={styles.gridContainer}>
-                            <Box sx={styles.containerActions}>
+                            <Box sx={styles.containerActions.both}>
+                                <p style={{marginTop: '24px'}}>
+                                    Automatically Clean Fields 
+                                    <Switch checked={autoCleanFields} onChange={() => setAutoCleanFields(!autoCleanFields)} size='small'/>
+                                </p>
                                 <p>
                                     Raw Values 
                                     <Switch checked={showRawValues} onChange={() => setShowRawValues(!showRawValues)} size='small'/>
+                                    <IconButton id='fullscreen-table-button' onClick={() => handleSetFullscreen("table")}>
+                                        { 
+                                            fullscreen === "table" ? <FullscreenExitIcon/> : <FullscreenIcon/> 
+                                        }
+                                    </IconButton>
                                 </p>
-                                <IconButton id='fullscreen-table-button' onClick={() => handleSetFullscreen("table")}>
-                                    { 
-                                        fullscreen === "table" ? <FullscreenExitIcon/> : <FullscreenIcon/> 
-                                    }
-                                </IconButton>
+                                
                             </Box>
                             {attributesList !== undefined && 
                                 <AttributesTable 
@@ -307,7 +313,7 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
                                     forceOpenSubtable={forceOpenSubtable}
                                     displayKeyIndex={displayKeyIndex}
                                     displayKeySubattributeIndex={displayKeySubattributeIndex}
-                                    handleUpdateRecord={handleUpdateRecord}
+                                    handleUpdateRecord={() => handleUpdateRecord(autoCleanFields)}
                                     locked={locked}
                                     showRawValues={showRawValues}
                                 />
@@ -319,7 +325,7 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
                 {fullscreen !== "table" && 
                     <Grid item xs={gridWidths[0]}>
                         <Box sx={styles.gridContainer}>
-                            <Box sx={styles.containerActions}>
+                            <Box sx={styles.containerActions.right}>
                                 <IconButton id='fullscreen-image-button' onClick={() => handleSetFullscreen("image")}>
                                     { 
                                         fullscreen === "image" ? <FullscreenExitIcon/> : <FullscreenIcon/> 

--- a/src/components/DocumentContainer/DocumentContainer.tsx
+++ b/src/components/DocumentContainer/DocumentContainer.tsx
@@ -290,8 +290,8 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
                         <Box sx={styles.gridContainer}>
                             <Box sx={styles.containerActions.both}>
                                 <p style={{marginTop: '24px'}}>
-                                    Automatically Clean Fields 
-                                    <Switch checked={autoCleanFields} onChange={() => setAutoCleanFields(!autoCleanFields)} size='small'/>
+                                    {/* Automatically Clean Fields 
+                                    <Switch checked={autoCleanFields} onChange={() => setAutoCleanFields(!autoCleanFields)} size='small'/> */}
                                 </p>
                                 <p>
                                     Raw Values 

--- a/src/components/DocumentContainer/DocumentContainer.tsx
+++ b/src/components/DocumentContainer/DocumentContainer.tsx
@@ -8,7 +8,7 @@ import { useKeyDown } from '../../assets/util';
 import AttributesTable from '../RecordAttributesTable/RecordAttributesTable';
 import { DocumentContainerProps } from '../../types';
 import { DocumentContainerStyles as styles } from '../../assets/styles';
-
+import Switch from '@mui/material/Switch';
 
 const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, handleUpdateRecord, locked }: DocumentContainerProps) => {
     const [imgIndex, setImgIndex] = useState(0);
@@ -21,6 +21,7 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
     const [height, setHeight] = useState("auto");
     const [forceOpenSubtable, setForceOpenSubtable] = useState<number | null>(null);
     const [imageHeight, setImageHeight] = useState(0);
+    const [ showRawValues, setShowRawValues ] = useState(false)
     const imageDivStyle = {
         width: width,
         height: height,
@@ -287,6 +288,10 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
                     <Grid item xs={gridWidths[2]}>
                         <Box sx={styles.gridContainer}>
                             <Box sx={styles.containerActions}>
+                                <p>
+                                    Raw Values 
+                                    <Switch checked={showRawValues} onChange={() => setShowRawValues(!showRawValues)} size='small'/>
+                                </p>
                                 <IconButton id='fullscreen-table-button' onClick={() => handleSetFullscreen("table")}>
                                     { 
                                         fullscreen === "table" ? <FullscreenExitIcon/> : <FullscreenIcon/> 
@@ -304,6 +309,7 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
                                     displayKeySubattributeIndex={displayKeySubattributeIndex}
                                     handleUpdateRecord={handleUpdateRecord}
                                     locked={locked}
+                                    showRawValues={showRawValues}
                                 />
                             }
                         </Box>

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -210,7 +210,7 @@ const AttributeRow = (props: AttributeRowProps) => {
                                 onChange={(e) => handleChangeValue(e, idx)} 
                                 onFocus={(event) => event.target.select()}
                                 id='edit-field-text-box'
-                                sx={styles.errorTextField}
+                                sx={v.cleaning_error ? styles.errorTextField: {}}
                                 variant='outlined'
                             />
                             :

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -209,7 +209,7 @@ const AttributeRow = (props: AttributeRowProps) => {
                             id='edit-field-text-box'
                         />
                         :
-                        <Tooltip title={v.edited ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy || 'unknown'}` : ''}>
+                        <Tooltip title={(v.edited && v.lastUpdated) ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy || 'unknown'}` : ''}>
                             <span>
                                 {formatAttributeValue(v.value)}&nbsp;
                                 {isSelected && !locked &&
@@ -484,7 +484,7 @@ const SubattributeRow = (props: SubattributeRowProps) => {
                         onFocus={(event) => event.target.select()}
                     />
                     :
-                    <Tooltip title={v.edited ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy}` : ''}>
+                    <Tooltip title={(v.edited && v.lastUpdated) ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy}` : ''}>
                         <span>
                             {formatAttributeValue(v.value)}&nbsp;
                             {isSelected && !locked &&

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -26,7 +26,8 @@ const AttributesTable = (props: AttributesTableProps) => {
         displayKeyIndex,
         displayKeySubattributeIndex,
         handleUpdateRecord,
-        locked
+        locked,
+        showRawValues=true
     } = props;
 
     const handleClickOutside = () => {
@@ -41,6 +42,9 @@ const AttributesTable = (props: AttributesTableProps) => {
                     <TableRow>
                         <TableCell sx={styles.headerRow}>Field</TableCell>
                         <TableCell sx={styles.headerRow}>Value</TableCell>
+                        {showRawValues &&
+                            <TableCell sx={styles.headerRow}>Raw Value</TableCell>
+                        }
                         <TableCell sx={styles.headerRow}>Confidence</TableCell>
                     </TableRow>
                 </TableHead>
@@ -59,6 +63,7 @@ const AttributesTable = (props: AttributesTableProps) => {
                             displayKeySubattributeIndex={displayKeySubattributeIndex}
                             handleUpdateRecord={handleUpdateRecord}
                             locked={locked}
+                            showRawValues={showRawValues}
                         />
                     ))}
                 </TableBody>
@@ -87,7 +92,8 @@ const AttributeRow = (props: AttributeRowProps) => {
         displayKeyIndex, 
         displayKeySubattributeIndex, 
         handleUpdateRecord,
-        locked
+        locked,
+        showRawValues
     } = props;
     
     const [ editMode, setEditMode ] = useState(false);
@@ -190,7 +196,7 @@ const AttributeRow = (props: AttributeRowProps) => {
                 v.subattributes ? 
                 <TableCell></TableCell> 
                 :
-                <TableCell onKeyDown={handleKeyDown}>
+                <TableCell onKeyDown={handleKeyDown} sx={v.cleaning_error ? {backgroundColor: '#FECDD3'} : {}}>
                     {editMode ? 
                         <TextField 
                             onClick={(e) => e.stopPropagation()}
@@ -212,6 +218,13 @@ const AttributeRow = (props: AttributeRowProps) => {
                             }
                         </span>
                     }
+                </TableCell>
+            }
+            {showRawValues &&
+                <TableCell>
+                    <span >
+                        {v.raw_text}&nbsp;
+                    </span>
                 </TableCell>
             }
             <TableCell align="right" id={v.key+'_confidence'}>
@@ -268,6 +281,7 @@ const AttributeRow = (props: AttributeRowProps) => {
                 displayKeySubattributeIndex={displayKeySubattributeIndex}
                 topLevelIdx={idx}
                 locked={locked}
+                showRawValues={showRawValues}
             />
         }
     </>
@@ -291,7 +305,8 @@ const SubattributesTable = (props: SubattributesTableProps) => {
         displayKeyIndex,
         displayKeySubattributeIndex,
         handleUpdateRecord,
-        locked
+        locked,
+        showRawValues
     } = props;
 
     return (
@@ -307,6 +322,9 @@ const SubattributesTable = (props: SubattributesTableProps) => {
                     <TableRow>
                         <TableCell sx={styles.headerRow}>Field</TableCell>
                         <TableCell sx={styles.headerRow}>Value</TableCell>
+                        {showRawValues &&
+                            <TableCell sx={styles.headerRow}>Raw Value</TableCell>
+                        }
                         <TableCell sx={styles.headerRow}>Confidence</TableCell>
                     </TableRow>
                     </TableHead>
@@ -325,6 +343,7 @@ const SubattributesTable = (props: SubattributesTableProps) => {
                             idx={idx}
                             topLevelIdx={topLevelIdx}
                             locked={locked}
+                            showRawValues={showRawValues}
                         />
                     ))}
                     </TableBody>
@@ -355,7 +374,8 @@ const SubattributeRow = (props: SubattributeRowProps) => {
         displayKeySubattributeIndex,
         handleUpdateRecord,
         idx,
-        locked
+        locked,
+        showRawValues
     } = props;
 
     const [ editMode, setEditMode ] = useState(false);
@@ -450,7 +470,7 @@ const SubattributeRow = (props: SubattributeRowProps) => {
                     {k}
                 </span>
             </TableCell>
-            <TableCell onKeyDown={handleKeyDown}>
+            <TableCell onKeyDown={handleKeyDown} sx={v.cleaning_error ? {backgroundColor: '#FECDD3'} : {}}>
                 {editMode ? 
                     <TextField 
                         onClick={(e) => e.stopPropagation()}
@@ -472,6 +492,13 @@ const SubattributeRow = (props: SubattributeRowProps) => {
                     </span>
                 }
             </TableCell>
+            {showRawValues &&
+                <TableCell>
+                    <span>
+                        {v.raw_text}&nbsp;
+                    </span>
+                </TableCell>
+            }
             <TableCell>{formatConfidence(v.confidence)}</TableCell>
         </TableRow>
     )

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableRow, TableContainer } from '@mui/material';
-import { Box, TextField, Collapse, Typography, IconButton, Badge } from '@mui/material';
-import { formatConfidence, useKeyDown, useOutsideClick, formatAttributeValue } from '../../assets/util';
+import { Box, TextField, Collapse, Typography, IconButton, Badge, Tooltip } from '@mui/material';
+import { formatConfidence, useKeyDown, useOutsideClick, formatAttributeValue, formatDateTime } from '../../assets/util';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import EditIcon from '@mui/icons-material/Edit';
@@ -209,14 +209,16 @@ const AttributeRow = (props: AttributeRowProps) => {
                             id='edit-field-text-box'
                         />
                         :
-                        <span>
-                            {formatAttributeValue(v.value)}&nbsp;
-                            {isSelected && !locked &&
-                                <IconButton id='edit-field-icon' sx={styles.rowIconButton} onClick={handleClickEditIcon}>
-                                    <EditIcon sx={styles.rowIcon}/>
-                                </IconButton>
-                            }
-                        </span>
+                        <Tooltip title={v.edited ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy || 'unknown'}` : ''}>
+                            <span>
+                                {formatAttributeValue(v.value)}&nbsp;
+                                {isSelected && !locked &&
+                                    <IconButton id='edit-field-icon' sx={styles.rowIconButton} onClick={handleClickEditIcon}>
+                                        <EditIcon sx={styles.rowIcon}/>
+                                    </IconButton>
+                                }
+                            </span>
+                        </Tooltip>
                     }
                 </TableCell>
             }
@@ -482,14 +484,16 @@ const SubattributeRow = (props: SubattributeRowProps) => {
                         onFocus={(event) => event.target.select()}
                     />
                     :
-                    <span>
-                        {formatAttributeValue(v.value)}&nbsp;
-                        {isSelected && !locked &&
-                            <IconButton sx={styles.rowIconButton} onClick={handleClickEditIcon}>
-                                <EditIcon sx={styles.rowIcon}/>
-                            </IconButton>
-                        }
-                    </span>
+                    <Tooltip title={v.edited ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy}` : ''}>
+                        <span>
+                            {formatAttributeValue(v.value)}&nbsp;
+                            {isSelected && !locked &&
+                                <IconButton sx={styles.rowIconButton} onClick={handleClickEditIcon}>
+                                    <EditIcon sx={styles.rowIcon}/>
+                                </IconButton>
+                            }
+                        </span>
+                    </Tooltip>
                 }
             </TableCell>
             {showRawValues &&

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableRow, TableContainer } from '@mui/material';
 import { Box, TextField, Collapse, Typography, IconButton, Badge } from '@mui/material';
-import { formatConfidence, useKeyDown, useOutsideClick } from '../../assets/util';
+import { formatConfidence, useKeyDown, useOutsideClick, formatAttributeValue } from '../../assets/util';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import EditIcon from '@mui/icons-material/Edit';
@@ -210,7 +210,7 @@ const AttributeRow = (props: AttributeRowProps) => {
                         />
                         :
                         <span>
-                            {v.value}&nbsp;
+                            {formatAttributeValue(v.value)}&nbsp;
                             {isSelected && !locked &&
                                 <IconButton id='edit-field-icon' sx={styles.rowIconButton} onClick={handleClickEditIcon}>
                                     <EditIcon sx={styles.rowIcon}/>
@@ -483,7 +483,7 @@ const SubattributeRow = (props: SubattributeRowProps) => {
                     />
                     :
                     <span>
-                        {v.value}&nbsp;
+                        {formatAttributeValue(v.value)}&nbsp;
                         {isSelected && !locked &&
                             <IconButton sx={styles.rowIconButton} onClick={handleClickEditIcon}>
                                 <EditIcon sx={styles.rowIcon}/>

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableRow, TableContainer } from '@mui/material';
-import { Box, TextField, Collapse, Typography, IconButton, Badge, Tooltip } from '@mui/material';
+import { Box, TextField, Collapse, Typography, IconButton, Badge, Tooltip, Stack } from '@mui/material';
 import { formatConfidence, useKeyDown, useOutsideClick, formatAttributeValue, formatDateTime } from '../../assets/util';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
@@ -196,30 +196,42 @@ const AttributeRow = (props: AttributeRowProps) => {
                 v.subattributes ? 
                 <TableCell></TableCell> 
                 :
-                <TableCell onKeyDown={handleKeyDown} sx={v.cleaning_error ? {backgroundColor: '#FECDD3'} : {}}>
-                    {editMode ? 
-                        <TextField 
-                            onClick={(e) => e.stopPropagation()}
-                            autoFocus
-                            name={k}
-                            size="small"
-                            defaultValue={v.value} 
-                            onChange={(e) => handleChangeValue(e, idx)} 
-                            onFocus={(event) => event.target.select()}
-                            id='edit-field-text-box'
-                        />
-                        :
-                        <Tooltip title={(v.edited && v.lastUpdated) ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy || 'unknown'}` : ''}>
-                            <span>
-                                {formatAttributeValue(v.value)}&nbsp;
-                                {isSelected && !locked &&
-                                    <IconButton id='edit-field-icon' sx={styles.rowIconButton} onClick={handleClickEditIcon}>
-                                        <EditIcon sx={styles.rowIcon}/>
-                                    </IconButton>
-                                }
-                            </span>
-                        </Tooltip>
+                <TableCell onKeyDown={handleKeyDown}>
+
+                <Stack direction='column'>
+                    <span style={v.cleaning_error ? styles.errorSpan : {}}>
+                        {editMode ? 
+                            <TextField 
+                                onClick={(e) => e.stopPropagation()}
+                                autoFocus
+                                name={k}
+                                size="small"
+                                defaultValue={v.value} 
+                                onChange={(e) => handleChangeValue(e, idx)} 
+                                onFocus={(event) => event.target.select()}
+                                id='edit-field-text-box'
+                                sx={styles.errorTextField}
+                                variant='outlined'
+                            />
+                            :
+                            <Tooltip title={(v.edited && v.lastUpdated) ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy || 'unknown'}` : ''}>
+                                <p style={v.cleaning_error ? styles.errorParagraph : styles.noErrorParagraph}>
+                                    {formatAttributeValue(v.value)}&nbsp;
+                                    {isSelected && !locked &&
+                                        <IconButton id='edit-field-icon' sx={styles.rowIconButton} onClick={handleClickEditIcon}>
+                                            <EditIcon sx={styles.rowIcon}/>
+                                        </IconButton>
+                                    }
+                                </p>
+                            </Tooltip>
+                        }
+                    </span>
+                    {
+                        v.cleaning_error && (
+                            <Typography noWrap component={'p'} sx={styles.errorText}>Error during cleaning</Typography>
+                        )
                     }
+                </Stack>
                 </TableCell>
             }
             {showRawValues &&

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -4,6 +4,7 @@ import { Box, TextField, Collapse, Typography, IconButton, Badge, Tooltip, Stack
 import { formatConfidence, useKeyDown, useOutsideClick, formatAttributeValue, formatDateTime } from '../../assets/util';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import InfoIcon from '@mui/icons-material/Info';
 import EditIcon from '@mui/icons-material/Edit';
 import { Attribute, RecordAttributesTableProps } from '../../types';
 import { styles } from '../../assets/styles';
@@ -228,7 +229,15 @@ const AttributeRow = (props: AttributeRowProps) => {
                     </span>
                     {
                         v.cleaning_error && (
-                            <Typography noWrap component={'p'} sx={styles.errorText}>Error during cleaning</Typography>
+                            <Typography noWrap component={'p'} sx={styles.errorText}>
+                                Error during cleaning 
+                                <Tooltip title={v.cleaning_error} onClick={(e) => e.stopPropagation()}>
+                                    <IconButton sx={styles.errorInfoIcon}>
+                                        <InfoIcon fontSize='inherit' color='inherit'/>
+                                    </IconButton>
+                                </Tooltip>
+                                
+                            </Typography>
                         )
                     }
                 </Stack>

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -193,7 +193,7 @@ const AttributeRow = (props: AttributeRowProps) => {
                     </IconButton>
                 }
             </TableCell>
-            {
+            { // TODO: add styling to parent attribute if subattributes have errors
                 v.subattributes ? 
                 <TableCell></TableCell> 
                 :

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -494,28 +494,46 @@ const SubattributeRow = (props: SubattributeRowProps) => {
                 </span>
             </TableCell>
             <TableCell onKeyDown={handleKeyDown} sx={v.cleaning_error ? {backgroundColor: '#FECDD3'} : {}}>
-                {editMode ? 
-                    <TextField 
-                        onClick={(e) => e.stopPropagation()}
-                        autoFocus
-                        name={k}
-                        size="small" 
-                        defaultValue={v.value} 
-                        onChange={handleUpdateValue} 
-                        onFocus={(event) => event.target.select()}
-                    />
-                    :
-                    <Tooltip title={(v.edited && v.lastUpdated) ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy}` : ''}>
-                        <span>
-                            {formatAttributeValue(v.value)}&nbsp;
-                            {isSelected && !locked &&
-                                <IconButton sx={styles.rowIconButton} onClick={handleClickEditIcon}>
-                                    <EditIcon sx={styles.rowIcon}/>
-                                </IconButton>
-                            }
-                        </span>
-                    </Tooltip>
-                }
+                <Stack direction='column'>
+                    <span style={v.cleaning_error ? styles.errorSpan : {}}>
+                    {editMode ? 
+                        <TextField 
+                            onClick={(e) => e.stopPropagation()}
+                            autoFocus
+                            name={k}
+                            size="small" 
+                            defaultValue={v.value} 
+                            onChange={handleUpdateValue} 
+                            onFocus={(event) => event.target.select()}
+                            sx={v.cleaning_error ? styles.errorTextField: {}}
+                        />
+                        :
+                        <Tooltip title={(v.edited && v.lastUpdated) ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy}` : ''}>
+                            <p>
+                                {formatAttributeValue(v.value)}&nbsp;
+                                {isSelected && !locked &&
+                                    <IconButton sx={styles.rowIconButton} onClick={handleClickEditIcon}>
+                                        <EditIcon sx={styles.rowIcon}/>
+                                    </IconButton>
+                                }
+                            </p>
+                        </Tooltip>
+                    }
+                    </span>
+                    {
+                        v.cleaning_error && (
+                            <Typography noWrap component={'p'} sx={styles.errorText}>
+                                Error during cleaning 
+                                <Tooltip title={v.cleaning_error} onClick={(e) => e.stopPropagation()}>
+                                    <IconButton sx={styles.errorInfoIcon}>
+                                        <InfoIcon fontSize='inherit' color='inherit'/>
+                                    </IconButton>
+                                </Tooltip>
+                                
+                            </Typography>
+                        )
+                    }
+                </Stack>
             </TableCell>
             {showRawValues &&
                 <TableCell>

--- a/src/components/RecordGroupsTable/RecordGroupsTable.tsx
+++ b/src/components/RecordGroupsTable/RecordGroupsTable.tsx
@@ -45,7 +45,7 @@ const RecordGroupsTable = ({ record_groups }: RecordGroupsTableProps) => {
                 {row.reviewed_amt || 0} / {row.total_amt || 0}
                 {row.error_amt ? 
                   <Tooltip title='This record group contains cleaning errors'>
-                    <IconButton sx={{color: ERROR_TEXT_COLOR}}><WarningIcon/></IconButton>
+                    <IconButton sx={{color: ERROR_TEXT_COLOR}} size='small'><WarningIcon/></IconButton>
                   </Tooltip>
                   
                   :

--- a/src/components/RecordGroupsTable/RecordGroupsTable.tsx
+++ b/src/components/RecordGroupsTable/RecordGroupsTable.tsx
@@ -1,8 +1,9 @@
 import { useNavigate } from "react-router-dom";
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, IconButton, Tooltip } from '@mui/material';
 import { formatDate } from '../../assets/util';
 import { RecordGroup } from "../../types";
-import { styles } from "../../assets/styles";
+import { styles, ERROR_TEXT_COLOR } from "../../assets/styles";
+import WarningIcon from '@mui/icons-material/Warning';
 
 interface RecordGroupsTableProps {
   record_groups: RecordGroup[];
@@ -40,7 +41,17 @@ const RecordGroupsTable = ({ record_groups }: RecordGroupsTableProps) => {
               <TableCell>{row.description}</TableCell>
               <TableCell>{row.documentType}</TableCell>
               <TableCell>{row.state}</TableCell>
-              <TableCell>{row.reviewed_amt || 0} / {row.total_amt || 0}</TableCell>
+              <TableCell>
+                {row.reviewed_amt || 0} / {row.total_amt || 0}
+                {row.error_amt ? 
+                  <Tooltip title='This record group contains cleaning errors'>
+                    <IconButton sx={{color: ERROR_TEXT_COLOR}}><WarningIcon/></IconButton>
+                  </Tooltip>
+                  
+                  :
+                  null
+                }
+              </TableCell>
               <TableCell>{formatDate(row.dateCreated || null)}</TableCell>
             </TableRow>
           ))}

--- a/src/components/RecordsTable/RecordsTable.tsx
+++ b/src/components/RecordsTable/RecordsTable.tsx
@@ -179,6 +179,14 @@ const RecordsTable = (props: RecordsTableProps) => {
   }
 
   const tableCell = (row: RecordData, key: string) => {
+    // determine colors of status icons. this is getting more and more complicated...
+    let digitizationStatusIconColor = row.has_errors ? 'red' : 'green'
+    let reviewStatusIconColor = row.has_errors ? 'red' : 'green'
+    if (row.status === 'processing') digitizationStatusIconColor = '#EF6C0B'
+    if (row.verification_status === 'required' || row.review_status === 'incomplete') reviewStatusIconColor = '#E3B62E'
+    else if (row.review_status === "defective") reviewStatusIconColor = '#9F0100'
+    else if (row.review_status === 'unreviewed') reviewStatusIconColor = 'grey'
+    
     if (key === "name") return <TableCell key={key}>{row.name}</TableCell>
     if (key === "dateCreated") return <TableCell key={key} align="right">{formatDate(row.dateCreated)}</TableCell>
     if (key === "api_number") return <TableCell key={key} align="right">{row.api_number}</TableCell>
@@ -194,25 +202,20 @@ const RecordsTable = (props: RecordsTableProps) => {
     if (key === "status") return (
         <TableCell key={key} align="right">
           <Typography variant='inherit' noWrap>
-          {
-            row.status === "processing" ? 
-            <IconButton>
-              <CachedIcon sx={{ color: "#EF6C0B" }} /> 
-            </IconButton> :
-            row.status === "digitized" ? 
-            <IconButton>
-              <CheckCircleOutlineIcon sx={{ color: "green" }} />
-            </IconButton> :
-            row.status === "redigitized" ? 
-            <IconButton>
-              <PublishedWithChangesOutlinedIcon sx={{ color: "green" }} />
-            </IconButton> :
-            row.status === "error" ? 
-            <IconButton>
-              <ErrorIcon color="error" />
-            </IconButton> :
-            null
-          }
+            <IconButton sx={{ color: digitizationStatusIconColor }}>
+            {
+              row.status === "processing" ? 
+                <CachedIcon /> :
+              row.status === "digitized" ? 
+                <CheckCircleOutlineIcon /> :
+              row.status === "redigitized" ?
+                <PublishedWithChangesOutlinedIcon /> :
+              row.status === "error" ?
+                <ErrorIcon color="error" /> :
+              null
+            }
+            </IconButton>
+          
           {row.status}
           </Typography>
         </TableCell>
@@ -221,27 +224,22 @@ const RecordsTable = (props: RecordsTableProps) => {
     if (key === "review_status") return (
         <TableCell key={key} align="right">
           <Typography variant='inherit' noWrap>
-          <IconButton>
+          <IconButton sx={{ color: reviewStatusIconColor }}>
             {
               row.verification_status === 'required' ? 
-                <ErrorIcon sx={{ color: "#E3B62E" }} /> 
+                <ErrorIcon  /> 
               :
               row.review_status === "unreviewed" ? 
                 <ErrorIcon /> 
               :
               row.review_status === "incomplete" ? 
-                <ErrorIcon sx={{ color: "#E3B62E" }} /> 
+                <ErrorIcon /> 
               :
               row.review_status === "defective" ? 
-                <WarningIcon sx={{ color: "#9F0100" }} /> 
+                <WarningIcon /> 
               :
-              row.review_status === "reviewed" ? (
-                row.has_errors ? 
-                <CheckCircleIcon sx={{ color: "red" }} /> 
-                :
-                <CheckCircleIcon sx={{ color: "green" }} /> 
-              )
-                
+              row.review_status === "reviewed" ?
+                <CheckCircleIcon /> 
               :
               null
             }

--- a/src/components/RecordsTable/RecordsTable.tsx
+++ b/src/components/RecordsTable/RecordsTable.tsx
@@ -182,8 +182,8 @@ const RecordsTable = (props: RecordsTableProps) => {
     if (key === "name") return <TableCell key={key}>{row.name}</TableCell>
     if (key === "dateCreated") return <TableCell key={key} align="right">{formatDate(row.dateCreated)}</TableCell>
     if (key === "api_number") return <TableCell key={key} align="right">{row.api_number}</TableCell>
-    if (key === "confidence_median") return <TableCell key={key} align="right">{(row.status === "digitized" || row.status === "reprocessed") && calculateAverageConfidence(row.attributesList)}</TableCell>
-    if (key === "confidence_lowest") return <TableCell key={key} align="right">{(row.status === "digitized" || row.status === "reprocessed") && calculateLowestConfidence(row.attributesList)}</TableCell>
+    if (key === "confidence_median") return <TableCell key={key} align="right">{(row.status === "digitized" || row.status === "redigitized") && calculateAverageConfidence(row.attributesList)}</TableCell>
+    if (key === "confidence_lowest") return <TableCell key={key} align="right">{(row.status === "digitized" || row.status === "redigitized") && calculateLowestConfidence(row.attributesList)}</TableCell>
     if (key === "notes") return (
       <TableCell key={key} align="right">
           <IconButton sx={(!row.record_notes || row.record_notes?.length === 0) ? {} : { color: "#F2DB6F" }} onClick={(e) => handleClickNotes(e, row)}>
@@ -203,7 +203,7 @@ const RecordsTable = (props: RecordsTableProps) => {
             <IconButton>
               <CheckCircleOutlineIcon sx={{ color: "green" }} />
             </IconButton> :
-            row.status === "reprocessed" ? 
+            row.status === "redigitized" ? 
             <IconButton>
               <PublishedWithChangesOutlinedIcon sx={{ color: "green" }} />
             </IconButton> :
@@ -235,8 +235,13 @@ const RecordsTable = (props: RecordsTableProps) => {
               row.review_status === "defective" ? 
                 <WarningIcon sx={{ color: "#9F0100" }} /> 
               :
-              row.review_status === "reviewed" ? 
+              row.review_status === "reviewed" ? (
+                row.has_errors ? 
+                <CheckCircleIcon sx={{ color: "red" }} /> 
+                :
                 <CheckCircleIcon sx={{ color: "green" }} /> 
+              )
+                
               :
               null
             }

--- a/src/components/Subheader/Subheader.tsx
+++ b/src/components/Subheader/Subheader.tsx
@@ -64,7 +64,7 @@ const Subheader = (props: SubheaderProps) => {
                     </div>
                     <div style={styles.pageName}>
                         {currentPage}&nbsp;
-                        {actions &&
+                        {actions && Object.keys(actions).length > 0 &&
                             <>
                                 <IconButton 
                                     id="options-button"

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -125,6 +125,14 @@ export const downloadRecords = (location: string, _id: string, export_types: { [
     });
 };
 
+export const cleanRecords = (location: string, _id: string) => {
+    return fetch(BACKEND_URL + '/run_cleaning_functions/' + location + '/' + _id, {
+        method: 'POST',
+        mode: 'cors',
+        headers: { "Authorization": "Bearer " + localStorage.getItem("id_token") }
+    });
+};
+
 export const updateProject = (project_id: string, data: any) => {
     return fetch(BACKEND_URL + '/update_project/' + project_id, {
         method: 'POST',

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface RecordData {
     verification_status?: string;
     lastUpdated?: number;
     lastUpdatedBy?: string;
+    has_errors?: boolean;
 }
 
 export interface ProjectData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export interface Attribute {
     name: string;
     key: string;
     value: string;
-    raw_value: string;
+    raw_text: string;
     normalized_value: string;
     uncleaned_value?: string;
     cleaned?: boolean;
@@ -129,6 +129,7 @@ export interface RecordAttributesTableProps {
     displayKeySubattributeIndex: number | null;
     handleUpdateRecord: () => void;
     locked?: boolean;
+    showRawValues?: boolean;
 }
 
 export interface RecordsTableProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,10 @@ export interface TableColumns {
     keyNames: string[];
 }
 
+export interface SubheaderActions {
+    [key: string]: () => void;
+}
+
 /*
 props interfaces
 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export interface RecordAttributesTableProps {
     fullscreen: string | null;
     displayKeyIndex: number;
     displayKeySubattributeIndex: number | null;
-    handleUpdateRecord: () => void;
+    handleUpdateRecord: (...args: any[]) => void;
     locked?: boolean;
     showRawValues?: boolean;
 }
@@ -221,7 +221,7 @@ export interface DocumentContainerProps {
     imageFiles: string[];
     attributesList: any[];
     handleChangeValue: handleChangeValueSignature;
-    handleUpdateRecord: () => void;
+    handleUpdateRecord: (...args: any[]) => void;
     locked?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,11 @@ export interface Attribute {
     name: string;
     key: string;
     value: string;
+    raw_value: string;
+    normalized_value: string;
+    uncleaned_value?: string;
+    cleaned?: boolean;
+    cleaning_error?: boolean;
     confidence: number | null;
     edited?: boolean;
     normalized_vertices: number[][] | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,9 +51,9 @@ export interface RecordGroup {
 export interface Attribute {
     name: string;
     key: string;
-    value: string;
+    value: string | boolean | number | null;
     raw_text: string;
-    normalized_value: string;
+    normalized_value: string | boolean;
     uncleaned_value?: string;
     cleaned?: boolean;
     cleaning_error?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface RecordGroup {
     dateCreated?: number;
     reviewed_amt?: number;
     total_amt?: number;
+    error_amt?: number;
 }
 
 export interface Attribute {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,8 @@ export interface RecordData {
     review_status?: string;
     notes?: string | null;
     verification_status?: string;
+    lastUpdated?: number;
+    lastUpdatedBy?: string;
 }
 
 export interface ProjectData {
@@ -61,6 +63,8 @@ export interface Attribute {
     edited?: boolean;
     normalized_vertices: number[][] | null;
     subattributes?: Attribute[];
+    lastUpdated?: number;
+    lastUpdatedBy?: string;
 }
 
 export interface Processor {

--- a/src/views/RecordGroupPage/RecordGroupPage.tsx
+++ b/src/views/RecordGroupPage/RecordGroupPage.tsx
@@ -8,7 +8,7 @@ import UploadDocumentsModal from '../../components/UploadDocumentsModal/UploadDo
 import PopupModal from '../../components/PopupModal/PopupModal';
 import ErrorBar from '../../components/ErrorBar/ErrorBar';
 import { callAPI } from '../../assets/util';
-import { RecordGroup, ProjectData, PreviousPages } from '../../types';
+import { RecordGroup, ProjectData, PreviousPages, SubheaderActions } from '../../types';
 import { useUserContext } from '../../usercontext';
 
 const RecordGroupPage = () => {
@@ -23,6 +23,7 @@ const RecordGroupPage = () => {
     const [openUpdateNameModal, setOpenUpdateNameModal] = useState(false);
     const [recordGroupName, setRecordGroupName] = useState("");
     const [errorMsg, setErrorMsg] = useState<string | null>("");
+    const [ subheaderActions, setSubheaderActions ] = useState<SubheaderActions>()
     const [navigation, setNavigation] = useState<PreviousPages>({"Projects": () => navigate("/projects", { replace: true })})
 
     useEffect(() => {
@@ -38,6 +39,20 @@ const RecordGroupPage = () => {
         temp_navigation[project.name] = () => navigate("/project/"+project._id, { replace: true })
         setNavigation(temp_navigation)
     }, [project]);
+
+    useEffect(() => {
+        let tempActions = {} as SubheaderActions
+        if (userPermissions && userPermissions.includes('manage_project')) {
+            tempActions['Change record group name'] = handleClickChangeName
+        }
+        if (userPermissions && userPermissions.includes('clean_record')) {
+            tempActions["Clean records"] = () => setOpenCleanPrompt(true)
+        }
+        if (userPermissions && userPermissions.includes('delete')) {
+            tempActions["Delete record group"] = () => setOpenDeleteModal(true)
+        }
+        setSubheaderActions(tempActions)
+    }, [userPermissions]);
 
     const styles = {
         outerBox: {
@@ -146,15 +161,7 @@ const RecordGroupPage = () => {
                 currentPage={recordGroup.name}
                 buttonName={(userPermissions && userPermissions.includes('upload_document')) ? "Upload new record(s)" : undefined}
                 handleClickButton={() => setShowDocumentModal(true)}
-                actions={(userPermissions && userPermissions.includes('manage_project')) ?
-                    {
-                        "Clean records": () => setOpenCleanPrompt(true),
-                        "Change record group name": handleClickChangeName, 
-                        "Delete record group": () => setOpenDeleteModal(true),
-                    }
-                    :
-                    null
-                }
+                actions={subheaderActions}
                 previousPages={navigation}
             />
             <Box sx={styles.innerBox}>

--- a/src/views/RecordGroupPage/RecordGroupPage.tsx
+++ b/src/views/RecordGroupPage/RecordGroupPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box } from '@mui/material';
 import { useParams, useNavigate } from "react-router-dom";
-import { getRecordGroup, uploadDocument, deleteRecordGroup, updateRecordGroup } from '../../services/app.service';
+import { getRecordGroup, uploadDocument, deleteRecordGroup, updateRecordGroup, cleanRecords } from '../../services/app.service';
 import RecordsTable from '../../components/RecordsTable/RecordsTable';
 import Subheader from '../../components/Subheader/Subheader';
 import UploadDocumentsModal from '../../components/UploadDocumentsModal/UploadDocumentsModal';
@@ -19,6 +19,7 @@ const RecordGroupPage = () => {
     const [recordGroup, setRecordGroup] = useState<RecordGroup>({ } as RecordGroup);
     const [showDocumentModal, setShowDocumentModal] = useState(false);
     const [openDeleteModal, setOpenDeleteModal] = useState(false);
+    const [openCleanPrompt, setOpenCleanPrompt] = useState(false);
     const [openUpdateNameModal, setOpenUpdateNameModal] = useState(false);
     const [recordGroupName, setRecordGroupName] = useState("");
     const [errorMsg, setErrorMsg] = useState<string | null>("");
@@ -125,6 +126,20 @@ const RecordGroupPage = () => {
         setErrorMsg(e)
     }
 
+    const runCleaningFunctions = () => {
+        callAPI(
+            cleanRecords,
+            ['record_group', params.id],
+            handleSuccessfulClean,
+            handleAPIErrorResponse
+        );
+    }
+
+    const handleSuccessfulClean = () => {
+        setOpenCleanPrompt(false)
+        window.location.reload()
+    }
+
     return (
         <Box sx={styles.outerBox}>
             <Subheader
@@ -133,6 +148,7 @@ const RecordGroupPage = () => {
                 handleClickButton={() => setShowDocumentModal(true)}
                 actions={(userPermissions && userPermissions.includes('manage_project')) ?
                     {
+                        "Clean records": () => setOpenCleanPrompt(true),
                         "Change record group name": handleClickChangeName, 
                         "Delete record group": () => setOpenDeleteModal(true),
                     }
@@ -161,6 +177,16 @@ const RecordGroupPage = () => {
                 handleSave={handleDeleteRecordGroup}
                 buttonText='Delete'
                 buttonColor='error'
+                buttonVariant='contained'
+                width={400}
+            />
+            <PopupModal
+                open={openCleanPrompt}
+                handleClose={() => setOpenCleanPrompt(false)}
+                text="Are you sure you want to clean all the records in this record group?"
+                handleSave={runCleaningFunctions}
+                buttonText='Clean Records'
+                buttonColor='primary'
                 buttonVariant='contained'
                 width={400}
             />

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -8,7 +8,7 @@ import Bottombar from '../../components/BottomBar/BottomBar';
 import DocumentContainer from '../../components/DocumentContainer/DocumentContainer';
 import PopupModal from '../../components/PopupModal/PopupModal';
 import ErrorBar from '../../components/ErrorBar/ErrorBar';
-import { RecordData, handleChangeValueSignature, PreviousPages } from '../../types';
+import { RecordData, handleChangeValueSignature, PreviousPages, SubheaderActions } from '../../types';
 import { useUserContext } from '../../usercontext';
 
 const Record = () => {
@@ -21,6 +21,7 @@ const Record = () => {
     const [errorMsg, setErrorMsg] = useState<string | null>("");
     const [showResetPrompt, setShowResetPrompt] = useState(false);
     const [ lastUpdatedField, setLastUpdatedField ] = useState<any>()
+    const [ subheaderActions, setSubheaderActions ] = useState<SubheaderActions>()
     const [locked, setLocked] = useState(false)
     const params = useParams<{ id: string }>();
     const navigate = useNavigate();
@@ -58,6 +59,20 @@ const Record = () => {
             handleFailedFetchRecord,
         )
     }, [params.id]);
+
+    useEffect(() => {
+        let tempActions = {
+            "Change record name": () => setOpenUpdateNameModal(true)
+        } as SubheaderActions
+        if (userPermissions && userPermissions.includes('clean_record')) {
+            tempActions["Clean record"] = () => setOpenUpdateNameModal(true)
+            tempActions["Reset record"] = () => setShowResetPrompt(true)
+        }
+        if (userPermissions && userPermissions.includes('delete')) {
+            tempActions["Delete record"] = () => setOpenDeleteModal(true)
+        }
+        setSubheaderActions(tempActions)
+    }, [userPermissions])
 
     const handleFailedFetchRecord = (data: any, response_status?: number) => {
         if (response_status === 303) {
@@ -280,17 +295,7 @@ const Record = () => {
         <Box sx={styles.outerBox}>
             <Subheader
                 currentPage={`${recordData.recordIndex !== undefined ? recordData.recordIndex : ""}. ${recordData.name !== undefined ? recordData.name : ""}`}
-                actions={(userPermissions && userPermissions.includes('delete')) ?
-                    {
-                        "Clean record": () => setOpenCleanPrompt(true),
-                        "Change record name": () => setOpenUpdateNameModal(true),
-                        "Delete record": () => setOpenDeleteModal(true),
-                    }
-                    :
-                    {
-                        "Change record name": () => setOpenUpdateNameModal(true),
-                    }
-                }
+                actions={subheaderActions}
                 previousPages={previousPages}
                 status={recordData.review_status}
                 verification_status={recordData.verification_status}

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -19,6 +19,7 @@ const Record = () => {
     const [previousPages, setPreviousPages] = useState<PreviousPages>({ "Projects": () => navigate("/projects", { replace: true }) });
     const [errorMsg, setErrorMsg] = useState<string | null>("");
     const [showResetPrompt, setShowResetPrompt] = useState(false);
+    const [ lastUpdatedField, setLastUpdatedField ] = useState<any>()
     const [locked, setLocked] = useState(false)
     const params = useParams<{ id: string }>();
     const navigate = useNavigate();
@@ -109,7 +110,7 @@ const Record = () => {
         if (locked) return
         callAPI(
             updateRecord,
-            [params.id, { data: recordData, type: "attributesList" }],
+            [params.id, { data: recordData, type: "attributesList", fieldToClean: lastUpdatedField }],
             handleSuccessfulAttributeUpdate,
             handleFailedUpdate
         );
@@ -119,7 +120,7 @@ const Record = () => {
         let tempRecordData = { ...recordData } as RecordData;
         tempRecordData["attributesList"] = data["attributesList"]
         if (data["review_status"]) tempRecordData["review_status"] = data["review_status"]
-        
+        setLastUpdatedField(undefined)
         setRecordData(tempRecordData);
     }
 
@@ -162,6 +163,12 @@ const Record = () => {
         tempRecordData.attributesList = tempAttributesList;
         tempRecordData.lastUpdated = rightNow;
         tempRecordData.lastUpdatedBy = userEmail;
+        let tempLastUpdatedField = {
+            topLevelIndex: topLevelIndex,
+            'isSubattribute': isSubattribute,
+            'subIndex': subIndex
+        }
+        setLastUpdatedField(tempLastUpdatedField)
         setRecordData(tempRecordData);
     }
 

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -65,7 +65,7 @@ const Record = () => {
             "Change record name": () => setOpenUpdateNameModal(true)
         } as SubheaderActions
         if (userPermissions && userPermissions.includes('clean_record')) {
-            tempActions["Clean record"] = () => setOpenUpdateNameModal(true)
+            tempActions["Clean record"] = () => setOpenCleanPrompt(true)
             tempActions["Reset record"] = () => setShowResetPrompt(true)
         }
         if (userPermissions && userPermissions.includes('delete')) {

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -122,11 +122,13 @@ const Record = () => {
         );
     }
 
-    const handleUpdateRecord = () => {
+    const handleUpdateRecord = (cleanFields: boolean = true) => {
         if (locked) return
+        let body = { data: recordData, type: "attributesList", fieldToClean: null }
+        if (cleanFields) body['fieldToClean'] = lastUpdatedField
         callAPI(
             updateRecord,
-            [params.id, { data: recordData, type: "attributesList", fieldToClean: lastUpdatedField }],
+            [params.id, body],
             handleSuccessfulAttributeUpdate,
             handleFailedUpdate
         );

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -341,7 +341,7 @@ const Record = () => {
             <PopupModal
                 open={showResetPrompt}
                 handleClose={() => setShowResetPrompt(false)}
-                text="Setting status to unreviewed will reset any changes made. Are you sure you want to continue?"
+                text="Setting status to unreviewed will reset any changes made, and revert all fields to uncleaned values. Are you sure you want to continue?"
                 handleSave={() => handleUpdateReviewStatus("unreviewed")}
                 buttonText='Reset'
                 buttonColor='primary'

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -22,7 +22,7 @@ const Record = () => {
     const [locked, setLocked] = useState(false)
     const params = useParams<{ id: string }>();
     const navigate = useNavigate();
-    const { userPermissions} = useUserContext();
+    const { userPermissions, userEmail } = useUserContext();
 
     const styles = {
         outerBox: {
@@ -136,6 +136,7 @@ const Record = () => {
         let tempRecordData = { ...recordData };
         let tempAttributesList = [...tempRecordData.attributesList];
         let tempAttribute: any;
+        let rightNow = Date.now();
         if (isSubattribute) {
             let value = event.target.value;
             tempAttribute = tempAttributesList[topLevelIndex];
@@ -143,16 +144,24 @@ const Record = () => {
             let tempSubattribute = tempSubattributesList[subIndex!];
             tempSubattribute.value = value;
             tempAttribute.edited = true;
+            tempAttribute.lastUpdated = rightNow;
+            tempAttribute.lastUpdatedBy = userEmail
             tempSubattribute.edited = true;
+            tempSubattribute.lastUpdated = rightNow;
+            tempSubattribute.lastUpdatedBy = userEmail
             tempAttribute["subattributes"] = tempSubattributesList;
         } else {
             tempAttribute = tempAttributesList[topLevelIndex];
             let value = event.target.value;
             tempAttribute.value = value;
             tempAttribute.edited = true;
+            tempAttribute.lastUpdated = rightNow;
+            tempAttribute.lastUpdatedBy = userEmail
         }
         tempAttributesList[topLevelIndex] = tempAttribute;
         tempRecordData.attributesList = tempAttributesList;
+        tempRecordData.lastUpdated = rightNow;
+        tempRecordData.lastUpdatedBy = userEmail;
         setRecordData(tempRecordData);
     }
 


### PR DESCRIPTION
- update record view to include option for viewing raw fields
- display errors when present
- add lastupdated data to edited fields
- send field for cleaning when updating a field (not sure if we want to do this)
- relies on [server pr 104](https://github.com/CATALOG-Historic-Records/orphaned-wells-ui-server/pull/104)