### PR TITLE
Make cleaning optional; add processor deployment status and functionality

### DIFF
--- a/src/components/UploadDocumentsModal/UploadDirectory.tsx
+++ b/src/components/UploadDocumentsModal/UploadDirectory.tsx
@@ -10,7 +10,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 const UploadDirectory = (props: UploadDirectoryProps) => {
     const params = useParams<{ id: string }>();
     const { userEmail } = useUserContext();
-    const { directoryName, directoryFiles, runCleaningFunctions, setRunCleaningFunctions, undeployProcessor, setUndeployProcessor } = props;
+    const { directoryName, directoryFiles, runCleaningFunctions, setRunCleaningFunctions } = props;
     const [ amountToUpload, setAmountToUpload ] = useState(directoryFiles.length)
     const [ filesToUpload, setFilesToUpload ] = useState<File[]>([]) 
     const [ uploading, setUploading ] = useState(false)

--- a/src/components/UploadDocumentsModal/UploadDirectory.tsx
+++ b/src/components/UploadDocumentsModal/UploadDirectory.tsx
@@ -10,7 +10,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 const UploadDirectory = (props: UploadDirectoryProps) => {
     const params = useParams<{ id: string }>();
     const { userEmail } = useUserContext();
-    const { directoryName, directoryFiles } = props;
+    const { directoryName, directoryFiles, runCleaningFunctions, setRunCleaningFunctions } = props;
     const [ amountToUpload, setAmountToUpload ] = useState(directoryFiles.length)
     const [ filesToUpload, setFilesToUpload ] = useState<File[]>([]) 
     const [ uploading, setUploading ] = useState(false)
@@ -96,7 +96,7 @@ const UploadDirectory = (props: UploadDirectoryProps) => {
             formData.append('file', file, file.name);
             callAPI(
                 uploadDocument,
-                [formData, params.id, userEmail, false, preventDuplicates],
+                [formData, params.id, userEmail, false, preventDuplicates, runCleaningFunctions],
                 () => handleSuccessfulDocumentUpload(file),
                 (e, status) => handleAPIErrorResponse(file, status)
             );
@@ -165,16 +165,8 @@ const UploadDirectory = (props: UploadDirectoryProps) => {
                 </Stack>
             </Grid>
             <Grid item xs={12}>
-                <Box sx={{display: "flex", justifyContent: "space-around", marginTop: 3}}>
-                    {!uploading && !finishedUploading && 
-                        <Button variant="contained" sx={styles.button} onClick={upload} disabled={disabled}>
-                            Upload
-                        </Button>
-                    }
-                    {uploading && 
-                        <CircularProgress variant="determinate" value={progress} />
-                    }
-                    <div>
+                <Box sx={{display: "flex", justifyContent: "space-around", marginTop: 1}}>
+                    <Stack direction={'row'}>
                         <Tooltip title={'When selected, filenames that are already present in database will not be uploaded.'}>
                             <FormControlLabel 
                                 disabled={uploading}
@@ -184,7 +176,23 @@ const UploadDirectory = (props: UploadDirectoryProps) => {
                                 checked={preventDuplicates}
                             />
                         </Tooltip>
-                    </div>
+                        <FormControlLabel 
+                            control={<Switch/>} 
+                            label="Run cleaning functions" 
+                            onChange={(e: any) => setRunCleaningFunctions(e.target.checked)}
+                            checked={runCleaningFunctions}
+                        />
+                    </Stack>
+                </Box>
+                <Box sx={{display: "flex", justifyContent: "space-around", marginTop: 1}}>
+                    {!uploading && !finishedUploading && 
+                        <Button variant="contained" sx={styles.button} onClick={upload} disabled={disabled}>
+                            Upload
+                        </Button>
+                    }
+                    {uploading && 
+                        <CircularProgress variant="determinate" value={progress} />
+                    }
                 </Box>
             </Grid>
         </Grid>

--- a/src/components/UploadDocumentsModal/UploadDirectory.tsx
+++ b/src/components/UploadDocumentsModal/UploadDirectory.tsx
@@ -96,7 +96,7 @@ const UploadDirectory = (props: UploadDirectoryProps) => {
             formData.append('file', file, file.name);
             callAPI(
                 uploadDocument,
-                [formData, params.id, userEmail, false, preventDuplicates, runCleaningFunctions, undeployProcessor],
+                [formData, params.id, userEmail, false, preventDuplicates, runCleaningFunctions, false],
                 () => handleSuccessfulDocumentUpload(file),
                 (e, status) => handleAPIErrorResponse(file, status)
             );

--- a/src/components/UploadDocumentsModal/UploadDirectory.tsx
+++ b/src/components/UploadDocumentsModal/UploadDirectory.tsx
@@ -10,7 +10,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 const UploadDirectory = (props: UploadDirectoryProps) => {
     const params = useParams<{ id: string }>();
     const { userEmail } = useUserContext();
-    const { directoryName, directoryFiles, runCleaningFunctions, setRunCleaningFunctions } = props;
+    const { directoryName, directoryFiles, runCleaningFunctions, setRunCleaningFunctions, undeployProcessor, setUndeployProcessor } = props;
     const [ amountToUpload, setAmountToUpload ] = useState(directoryFiles.length)
     const [ filesToUpload, setFilesToUpload ] = useState<File[]>([]) 
     const [ uploading, setUploading ] = useState(false)
@@ -96,7 +96,7 @@ const UploadDirectory = (props: UploadDirectoryProps) => {
             formData.append('file', file, file.name);
             callAPI(
                 uploadDocument,
-                [formData, params.id, userEmail, false, preventDuplicates, runCleaningFunctions],
+                [formData, params.id, userEmail, false, preventDuplicates, runCleaningFunctions, undeployProcessor],
                 () => handleSuccessfulDocumentUpload(file),
                 (e, status) => handleAPIErrorResponse(file, status)
             );

--- a/src/components/UploadDocumentsModal/UploadDirectory.tsx
+++ b/src/components/UploadDocumentsModal/UploadDirectory.tsx
@@ -10,10 +10,9 @@ import CircularProgress from '@mui/material/CircularProgress';
 const UploadDirectory = (props: UploadDirectoryProps) => {
     const params = useParams<{ id: string }>();
     const { userEmail } = useUserContext();
-    const { directoryName, directoryFiles, runCleaningFunctions, setRunCleaningFunctions } = props;
+    const { directoryName, directoryFiles, runCleaningFunctions, setRunCleaningFunctions, uploading, setUploading } = props;
     const [ amountToUpload, setAmountToUpload ] = useState(directoryFiles.length)
-    const [ filesToUpload, setFilesToUpload ] = useState<File[]>([]) 
-    const [ uploading, setUploading ] = useState(false)
+    const [ filesToUpload, setFilesToUpload ] = useState<File[]>([])
     const [ finishedUploading, setFinishedUploading ] = useState(false)
     const [ progress, setProgress ] = useState(0)
     const [ preventDuplicates, setPreventDuplicates ] = useState(true)

--- a/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
+++ b/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
@@ -21,6 +21,7 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
     const [uploadDirectoryFiles, setUploadDirectoryFiles ] = useState<any>([])
     const [ runCleaningFunctions, setRunCleaningFunctions ] = useState(false)
     const [ processorState, setProcessorState ] = useState(10)
+    const [ uploadingDirectory, setUploadingDirectory ] = useState(false)
     const maxFileSize = 10;
     const fileTypes: string[] = ["tiff", "tif", "pdf", "png", "jpg", "jpeg", "zip"];
     const validFileTypes = ['image/png', 'application/pdf', 'image/tiff', 'image/jpeg']
@@ -105,7 +106,7 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                 setShowWarning(false);
             }, 5000);
         } else {
-            handleUploadDocument(file, runCleaningFunctions, false);
+            handleUploadDocument(file, runCleaningFunctions, true);
             setShowWarning(false);
             setShowModal(false);
         }
@@ -303,7 +304,7 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                             <Button 
                                 variant='outlined' 
                                 endIcon={<RocketLaunchIcon/>} 
-                                disabled={processorState > 3 || processorState === 2}
+                                disabled={processorState > 3 || processorState === 2 || uploadingDirectory}
                                 onClick={handleDeployProcessor}    
                             >
                                 {processorState === 1 ? 'Undeploy' : 'Deploy'} Processor
@@ -320,6 +321,8 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                         directoryFiles={uploadDirectoryFiles}
                         runCleaningFunctions={runCleaningFunctions}
                         setRunCleaningFunctions={setRunCleaningFunctions}
+                        uploading={uploadingDirectory}
+                        setUploading={setUploadingDirectory}
                     />  :
                     <>
                         <Tooltip title={processorState > 1 && 'Processor must be deployed to upload files'}>

--- a/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
+++ b/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
@@ -83,7 +83,7 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                 setShowWarning(false);
             }, 5000);
         } else {
-            handleUploadDocument(file);
+            handleUploadDocument(file, runCleaningFunctions);
             setShowWarning(false);
             setShowModal(false);
         }

--- a/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
+++ b/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, ChangeEvent } from 'react';
-import { Grid, Box, Modal, IconButton, Button } from '@mui/material';
+import { Grid, Box, Modal, IconButton, Button, Switch, FormControlLabel } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -18,6 +18,7 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
     const fileTypes: string[] = ["tiff", "tif", "pdf", "png", "jpg", "jpeg", "zip"];
     const validFileTypes = ['image/png', 'application/pdf', 'image/tiff', 'image/jpeg']
     const inputRef = useRef<HTMLInputElement>(null);
+    const [ runCleaningFunctions, setRunCleaningFunctions ] = useState(false)
 
     const styles = {
         modalStyle: {
@@ -99,7 +100,6 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
     };
 
     const handleChooseDirectory = (e: ChangeEvent<HTMLInputElement>) => {
-        // console.log(e.target.files)
         handleDirectoryInput(e.target.files)
         setShowWarning(false);
     }
@@ -217,6 +217,8 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                         setShowModal={setShowModal}
                         directoryName={uploadDirectory}
                         directoryFiles={uploadDirectoryFiles}
+                        runCleaningFunctions={runCleaningFunctions}
+                        setRunCleaningFunctions={setRunCleaningFunctions}
                     />  :
                     <>
                         <Grid item xs={12}>
@@ -236,6 +238,14 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                             
                         </Grid>
                         <Grid item xs={12}>
+                            <Box style={{display: "flex", justifyContent: "space-around"}}>
+                                <FormControlLabel 
+                                    control={<Switch/>} 
+                                    label="Run cleaning functions" 
+                                    onChange={(e: any) => setRunCleaningFunctions(e.target.checked)}
+                                    checked={runCleaningFunctions}
+                                />
+                            </Box>
                             <Box style={{display: "flex", justifyContent: "space-around"}}>
                                 <Button variant="contained" style={styles.button} onClick={handleClickUpload} disabled={file === null}>
                                     Upload File

--- a/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
+++ b/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
@@ -14,11 +14,12 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
     const [ file, setFile ] = useState<File | null>(null);
     const [uploadDirectory, setUploadDirectory] = useState<string>()
     const [uploadDirectoryFiles, setUploadDirectoryFiles ] = useState<any>([])
+    const [ runCleaningFunctions, setRunCleaningFunctions ] = useState(false)
+    const [ undeployProcessor, setUndeployProcessor ] = useState(true) 
     const maxFileSize = 10;
     const fileTypes: string[] = ["tiff", "tif", "pdf", "png", "jpg", "jpeg", "zip"];
     const validFileTypes = ['image/png', 'application/pdf', 'image/tiff', 'image/jpeg']
     const inputRef = useRef<HTMLInputElement>(null);
-    const [ runCleaningFunctions, setRunCleaningFunctions ] = useState(false)
 
     const styles = {
         modalStyle: {
@@ -83,7 +84,7 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                 setShowWarning(false);
             }, 5000);
         } else {
-            handleUploadDocument(file, runCleaningFunctions);
+            handleUploadDocument(file, runCleaningFunctions, undeployProcessor, false);
             setShowWarning(false);
             setShowModal(false);
         }
@@ -219,6 +220,8 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                         directoryFiles={uploadDirectoryFiles}
                         runCleaningFunctions={runCleaningFunctions}
                         setRunCleaningFunctions={setRunCleaningFunctions}
+                        undeployProcessor={undeployProcessor}
+                        setUndeployProcessor={setUndeployProcessor}
                     />  :
                     <>
                         <Grid item xs={12}>
@@ -244,6 +247,12 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                                     label="Run cleaning functions" 
                                     onChange={(e: any) => setRunCleaningFunctions(e.target.checked)}
                                     checked={runCleaningFunctions}
+                                />
+                                <FormControlLabel 
+                                    control={<Switch/>} 
+                                    label="Undeploy processor" 
+                                    onChange={(e: any) => setUndeployProcessor(e.target.checked)}
+                                    checked={undeployProcessor}
                                 />
                             </Box>
                             <Box style={{display: "flex", justifyContent: "space-around"}}>

--- a/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
+++ b/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, ChangeEvent } from 'react';
+import { useState, useRef, ChangeEvent, useEffect } from 'react';
+import { useParams } from "react-router-dom";
 import { Grid, Box, Modal, IconButton, Button, Switch, FormControlLabel } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
@@ -6,8 +7,11 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { FileUploader } from "react-drag-drop-files";
 import { UploadDocumentsModalProps } from '../../types';
 import UploadDirectory from './UploadDirectory';
+import { checkProcessorStatus } from '../../services/app.service';
+import { callAPI } from '../../util';
 
 const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
+    const params = useParams<{ id: string }>();
     const { setShowModal, handleUploadDocument } = props;
     const [ showWarning, setShowWarning ] = useState(false);
     const [ warningMessage, setWarningMessage ] = useState("");
@@ -20,6 +24,15 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
     const fileTypes: string[] = ["tiff", "tif", "pdf", "png", "jpg", "jpeg", "zip"];
     const validFileTypes = ['image/png', 'application/pdf', 'image/tiff', 'image/jpeg']
     const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        callAPI(
+            checkProcessorStatus,
+            [params.id],
+            (data) => handleCheckedProcessorStatus(data),
+            (e, status) => console.error(e)
+        );
+    }, [params.id])
 
     const styles = {
         modalStyle: {
@@ -71,6 +84,10 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
             justifyContent: 'center'
         },
     };
+
+    const handleCheckedProcessorStatus = (deployed: boolean) => {
+        console.log('processor is deployed: '+deployed)
+    }
 
     const handleClose = () => {
         setShowModal(false);
@@ -241,21 +258,15 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                             
                         </Grid>
                         <Grid item xs={12}>
-                            <Box style={{display: "flex", justifyContent: "space-around"}}>
+                            <Box sx={{display: "flex", justifyContent: "space-around", marginBottom: 1}}>
                                 <FormControlLabel 
                                     control={<Switch/>} 
                                     label="Run cleaning functions" 
                                     onChange={(e: any) => setRunCleaningFunctions(e.target.checked)}
                                     checked={runCleaningFunctions}
                                 />
-                                <FormControlLabel 
-                                    control={<Switch/>} 
-                                    label="Undeploy processor" 
-                                    onChange={(e: any) => setUndeployProcessor(e.target.checked)}
-                                    checked={undeployProcessor}
-                                />
                             </Box>
-                            <Box style={{display: "flex", justifyContent: "space-around"}}>
+                            <Box sx={{display: "flex", justifyContent: "space-around"}}>
                                 <Button variant="contained" style={styles.button} onClick={handleClickUpload} disabled={file === null}>
                                     Upload File
                                 </Button>

--- a/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
+++ b/src/components/UploadDocumentsModal/UploadDocumentsModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, ChangeEvent, useEffect } from 'react';
 import { useParams } from "react-router-dom";
-import { Grid, Box, Modal, IconButton, Button, Switch, FormControlLabel } from '@mui/material';
+import { Grid, Box, Modal, IconButton, Button, Switch, FormControlLabel, Badge, CircularProgress, Stack, Tooltip } from '@mui/material';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import CloseIcon from '@mui/icons-material/Close';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -19,7 +20,8 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
     const [uploadDirectory, setUploadDirectory] = useState<string>()
     const [uploadDirectoryFiles, setUploadDirectoryFiles ] = useState<any>([])
     const [ runCleaningFunctions, setRunCleaningFunctions ] = useState(false)
-    const [ undeployProcessor, setUndeployProcessor ] = useState(true) 
+    const [ undeployProcessor, setUndeployProcessor ] = useState(true)
+    const [ processorisDeployed, setProcessorIsDeployed ] = useState<boolean>()
     const maxFileSize = 10;
     const fileTypes: string[] = ["tiff", "tif", "pdf", "png", "jpg", "jpeg", "zip"];
     const validFileTypes = ['image/png', 'application/pdf', 'image/tiff', 'image/jpeg']
@@ -83,10 +85,13 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
             display: 'flex', 
             justifyContent: 'center'
         },
+        processorDeploymentText: {
+            margin:'10px'
+        }
     };
 
     const handleCheckedProcessorStatus = (deployed: boolean) => {
-        console.log('processor is deployed: '+deployed)
+        setProcessorIsDeployed(true)
     }
 
     const handleClose = () => {
@@ -200,6 +205,7 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                 onTypeError={fileTypeError}
                 onSizeError={fileSizeError}
                 maxSize={maxFileSize}
+                disabled={!processorisDeployed}
             />
         );
     };
@@ -230,6 +236,44 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                         <IconButton onClick={handleClose}><CloseIcon/></IconButton>
                     </Box>
                 </Grid>
+                <Grid item xs={12}>
+                    <Stack direction={'row'} justifyContent={'space-between'}>
+                        <span style={styles.processorDeploymentText}>
+                        Processor status: &nbsp; 
+                            {
+                                processorisDeployed === undefined ? (
+                                    <span>
+                                         <CircularProgress color='primary' size='16px'/>
+                                    </span>
+                                )
+                                : 
+                                !processorisDeployed ? (
+                                    <span>
+                                         &nbsp;
+                                        <Badge color="error" variant="dot"/>
+                                        &nbsp;
+                                        undeployed
+                                    </span>
+                                )
+                                : (
+                                    <span>
+                                         &nbsp;
+                                        <Badge color="secondary" variant="dot"/>
+                                        &nbsp;
+                                        deployed
+                                    </span>
+                                )
+                            }
+                        </span>
+                        <span>
+                            <Button variant='outlined' endIcon={<RocketLaunchIcon/>} disabled={processorisDeployed === undefined}>
+                                {processorisDeployed ? 'Undeploy' : 'Deploy'} Processor
+                            </Button>
+                        </span>
+                    </Stack>
+                    
+                        
+                </Grid>
                 {uploadDirectory ? 
                     <UploadDirectory
                         setShowModal={setShowModal}
@@ -241,9 +285,12 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                         setUndeployProcessor={setUndeployProcessor}
                     />  :
                     <>
-                        <Grid item xs={12}>
-                            {DragDrop()}
-                        </Grid>
+                        <Tooltip title={!processorisDeployed && 'Processor must be deployed to upload files'}>
+                            <Grid item xs={12}>
+                                
+                                {DragDrop()}
+                            </Grid>
+                        </Tooltip>
                         <Grid item xs={12}>
                         <input
                             ref={inputRef}
@@ -271,7 +318,7 @@ const UploadDocumentsModal = (props: UploadDocumentsModalProps) => {
                                     Upload File
                                 </Button>
                                 <p style={{display: 'flex', margin:0, alignItems: 'center'}}>or</p>
-                                <Button variant="outlined" style={styles.button} onClick={() => inputRef.current?.click()}>
+                                <Button variant="outlined" style={styles.button} onClick={() => inputRef.current?.click()} disabled={!processorisDeployed}>
                                     Choose Directory
                                 </Button>
                             </Box>

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -91,10 +91,10 @@ export const addRecordGroup = (data: any) => {
     });
 };
 
-export const uploadDocument = (data: FormData, project_id: string, user_email: any, reprocessed?: boolean, preventDuplicates?: boolean)  => {
+export const uploadDocument = (data: FormData, project_id: string, user_email: any, reprocessed?: boolean, preventDuplicates?: boolean, run_cleaning_functions: boolean = true)  => {
     if (!reprocessed) reprocessed = false
     if (!preventDuplicates) preventDuplicates = false
-    return fetch(BACKEND_URL + '/upload_document/' + project_id + '/' + user_email+'?reprocessed='+reprocessed+'&preventDuplicates='+preventDuplicates, {
+    return fetch(BACKEND_URL + '/upload_document/' + project_id + '/' + user_email+'?reprocessed='+reprocessed+'&preventDuplicates='+preventDuplicates+'&run_cleaning_functions='+run_cleaning_functions, {
         method: 'POST',
         mode: 'cors',
         body: data,

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -105,6 +105,7 @@ export const deployProcessor = (rg_id: string)  => {
     return fetch(BACKEND_URL + '/deploy_processor/'+rg_id, {
         method: 'POST',
         mode: 'cors',
+        headers: { "Authorization": "Bearer " + localStorage.getItem("id_token") }
     });
 };
 
@@ -112,6 +113,7 @@ export const undeployProcessor = (rg_id: string)  => {
     return fetch(BACKEND_URL + '/undeploy_processor/'+rg_id, {
         method: 'POST',
         mode: 'cors',
+        headers: { "Authorization": "Bearer " + localStorage.getItem("id_token") }
     });
 };
 
@@ -119,6 +121,7 @@ export const checkProcessorStatus = (rg_id: string)  => {
     return fetch(BACKEND_URL + '/check_processor_status/'+rg_id, {
         method: 'GET',
         mode: 'cors',
+        headers: { "Authorization": "Bearer " + localStorage.getItem("id_token") }
     });
 };
 

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -91,10 +91,10 @@ export const addRecordGroup = (data: any) => {
     });
 };
 
-export const uploadDocument = (data: FormData, project_id: string, user_email: any, reprocessed?: boolean, preventDuplicates?: boolean, run_cleaning_functions: boolean = true)  => {
+export const uploadDocument = (data: FormData, project_id: string, user_email: any, reprocessed?: boolean, preventDuplicates?: boolean, run_cleaning_functions: boolean = false, undeployProcessor: boolean = true)  => {
     if (!reprocessed) reprocessed = false
     if (!preventDuplicates) preventDuplicates = false
-    return fetch(BACKEND_URL + '/upload_document/' + project_id + '/' + user_email+'?reprocessed='+reprocessed+'&preventDuplicates='+preventDuplicates+'&run_cleaning_functions='+run_cleaning_functions, {
+    return fetch(BACKEND_URL + '/upload_document/' + project_id + '/' + user_email+'?reprocessed='+reprocessed+'&preventDuplicates='+preventDuplicates+'&run_cleaning_functions='+run_cleaning_functions+'&undeployProcessor='+undeployProcessor, {
         method: 'POST',
         mode: 'cors',
         body: data,

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -91,13 +91,34 @@ export const addRecordGroup = (data: any) => {
     });
 };
 
-export const uploadDocument = (data: FormData, project_id: string, user_email: any, reprocessed?: boolean, preventDuplicates?: boolean, run_cleaning_functions: boolean = false, undeployProcessor: boolean = true)  => {
+export const uploadDocument = (data: FormData, project_id: string, user_email: any, reprocessed?: boolean, preventDuplicates?: boolean, run_cleaning_functions: boolean = false, undeployProcessor: boolean = false)  => {
     if (!reprocessed) reprocessed = false
     if (!preventDuplicates) preventDuplicates = false
     return fetch(BACKEND_URL + '/upload_document/' + project_id + '/' + user_email+'?reprocessed='+reprocessed+'&preventDuplicates='+preventDuplicates+'&run_cleaning_functions='+run_cleaning_functions+'&undeployProcessor='+undeployProcessor, {
         method: 'POST',
         mode: 'cors',
         body: data,
+    });
+};
+
+export const deployProcessor = (rg_id: string)  => {
+    return fetch(BACKEND_URL + '/deploy_processor/'+rg_id, {
+        method: 'POST',
+        mode: 'cors',
+    });
+};
+
+export const undeployProcessor = (rg_id: string)  => {
+    return fetch(BACKEND_URL + '/undeploy_processor/'+rg_id, {
+        method: 'POST',
+        mode: 'cors',
+    });
+};
+
+export const checkProcessorStatus = (rg_id: string)  => {
+    return fetch(BACKEND_URL + '/check_processor_status/'+rg_id, {
+        method: 'GET',
+        mode: 'cors',
     });
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,8 +229,10 @@ export interface UploadDocumentsModalProps {
 
 export interface UploadDirectoryProps {
     setShowModal: (show: boolean) => void;
-    directoryFiles: File[]
-    directoryName: string
+    directoryFiles: File[];
+    directoryName: string;
+    runCleaningFunctions: boolean;
+    setRunCleaningFunctions: (show: boolean) => void;
 }
 
 export interface BottombarProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,7 +224,7 @@ export interface TableFiltersProps {
 
 export interface UploadDocumentsModalProps {
     setShowModal: (show: boolean) => void;
-    handleUploadDocument: (file: File, runCleaningFunctions: boolean, undeployProcessor: boolean, refresh?: boolean) => void;
+    handleUploadDocument: (file: File, runCleaningFunctions: boolean, refresh?: boolean) => void;
 }
 
 export interface UploadDirectoryProps {
@@ -233,8 +233,6 @@ export interface UploadDirectoryProps {
     directoryName: string;
     runCleaningFunctions: boolean;
     setRunCleaningFunctions: (show: boolean) => void;
-    undeployProcessor: boolean;
-    setUndeployProcessor: (show: boolean) => void;
 }
 
 export interface BottombarProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,7 +224,7 @@ export interface TableFiltersProps {
 
 export interface UploadDocumentsModalProps {
     setShowModal: (show: boolean) => void;
-    handleUploadDocument: (file: File, refresh?: boolean) => void;
+    handleUploadDocument: (file: File, runCleaningFunctions: boolean, undeployProcessor: boolean, refresh?: boolean) => void;
 }
 
 export interface UploadDirectoryProps {
@@ -233,6 +233,8 @@ export interface UploadDirectoryProps {
     directoryName: string;
     runCleaningFunctions: boolean;
     setRunCleaningFunctions: (show: boolean) => void;
+    undeployProcessor: boolean;
+    setUndeployProcessor: (show: boolean) => void;
 }
 
 export interface BottombarProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,6 +233,8 @@ export interface UploadDirectoryProps {
     directoryName: string;
     runCleaningFunctions: boolean;
     setRunCleaningFunctions: (show: boolean) => void;
+    uploading: boolean;
+    setUploading: (show: boolean) => void;
 }
 
 export interface BottombarProps {

--- a/src/views/RecordGroupPage/RecordGroupPage.tsx
+++ b/src/views/RecordGroupPage/RecordGroupPage.tsx
@@ -85,7 +85,7 @@ const RecordGroupPage = () => {
         formData.append('file', file, file.name);
         return callAPI(
             uploadDocument,
-            [formData, recordGroup._id, userEmail, false, false, runCleaningFunctions, undeployProcessor],
+            [formData, recordGroup._id, userEmail, false, false, runCleaningFunctions, false],
             () => handleSuccessfulDocumentUpload(refresh),
             handleAPIErrorResponse
         );

--- a/src/views/RecordGroupPage/RecordGroupPage.tsx
+++ b/src/views/RecordGroupPage/RecordGroupPage.tsx
@@ -80,12 +80,12 @@ const RecordGroupPage = () => {
         setProject(data.project)
     } 
 
-    const handleUploadDocument = (file: File, runCleaningFunctions: boolean = true, refresh: boolean = true) => {
+    const handleUploadDocument = (file: File, runCleaningFunctions: boolean = false, undeployProcessor: boolean = true, refresh: boolean = true) => {
         const formData = new FormData();
         formData.append('file', file, file.name);
         return callAPI(
             uploadDocument,
-            [formData, recordGroup._id, userEmail, false, false, runCleaningFunctions],
+            [formData, recordGroup._id, userEmail, false, false, runCleaningFunctions, undeployProcessor],
             () => handleSuccessfulDocumentUpload(refresh),
             handleAPIErrorResponse
         );

--- a/src/views/RecordGroupPage/RecordGroupPage.tsx
+++ b/src/views/RecordGroupPage/RecordGroupPage.tsx
@@ -80,7 +80,7 @@ const RecordGroupPage = () => {
         setProject(data.project)
     } 
 
-    const handleUploadDocument = (file: File, runCleaningFunctions: boolean = false, undeployProcessor: boolean = true, refresh: boolean = true) => {
+    const handleUploadDocument = (file: File, runCleaningFunctions: boolean = false, refresh: boolean = true) => {
         const formData = new FormData();
         formData.append('file', file, file.name);
         return callAPI(

--- a/src/views/RecordGroupPage/RecordGroupPage.tsx
+++ b/src/views/RecordGroupPage/RecordGroupPage.tsx
@@ -85,7 +85,7 @@ const RecordGroupPage = () => {
         formData.append('file', file, file.name);
         return callAPI(
             uploadDocument,
-            [formData, recordGroup._id, userEmail, false, runCleaningFunctions],
+            [formData, recordGroup._id, userEmail, false, false, runCleaningFunctions],
             () => handleSuccessfulDocumentUpload(refresh),
             handleAPIErrorResponse
         );

--- a/src/views/RecordGroupPage/RecordGroupPage.tsx
+++ b/src/views/RecordGroupPage/RecordGroupPage.tsx
@@ -80,12 +80,12 @@ const RecordGroupPage = () => {
         setProject(data.project)
     } 
 
-    const handleUploadDocument = (file: File, refresh: boolean = true) => {
+    const handleUploadDocument = (file: File, runCleaningFunctions: boolean = true, refresh: boolean = true) => {
         const formData = new FormData();
         formData.append('file', file, file.name);
         return callAPI(
             uploadDocument,
-            [formData, recordGroup._id, userEmail, false],
+            [formData, recordGroup._id, userEmail, false, runCleaningFunctions],
             () => handleSuccessfulDocumentUpload(refresh),
             handleAPIErrorResponse
         );


### PR DESCRIPTION
relies on [server pr#113](https://github.com/CATALOG-Historic-Records/orphaned-wells-ui-server/pull/113)
- add switch for turning cleaning on/off when uploading
- add deployment status of processor model to upload modal
- add button to deploy, undeploy processor model