### PR TITLE
Add new fields

### DIFF
--- a/src/components/DocumentContainer/DocumentContainer.tsx
+++ b/src/components/DocumentContainer/DocumentContainer.tsx
@@ -11,7 +11,7 @@ import { DocumentContainerProps } from '../../types';
 import { DocumentContainerStyles as styles } from '../../styles';
 import Switch from '@mui/material/Switch';
 
-const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, handleUpdateRecord, locked, recordSchema, insertField }: DocumentContainerProps) => {
+const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, handleUpdateRecord, locked, recordSchema, insertField, forceEditMode }: DocumentContainerProps) => {
     const [imgIndex, setImgIndex] = useState(0);
     const [displayPoints, setDisplayPoints] = useState<number[][] | null>(null);
     const [displayKeyIndex, setDisplayKeyIndex] = useState(-1);
@@ -376,6 +376,7 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
                                     showRawValues={showRawValues}
                                     recordSchema={recordSchema || {}}
                                     insertField={insertField}
+                                    forceEditMode={forceEditMode}
                                 />
                             }
                         </Box>

--- a/src/components/DocumentContainer/DocumentContainer.tsx
+++ b/src/components/DocumentContainer/DocumentContainer.tsx
@@ -11,7 +11,7 @@ import { DocumentContainerProps } from '../../types';
 import { DocumentContainerStyles as styles } from '../../styles';
 import Switch from '@mui/material/Switch';
 
-const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, handleUpdateRecord, locked, recordSchema }: DocumentContainerProps) => {
+const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, handleUpdateRecord, locked, recordSchema, insertField }: DocumentContainerProps) => {
     const [imgIndex, setImgIndex] = useState(0);
     const [displayPoints, setDisplayPoints] = useState<number[][] | null>(null);
     const [displayKeyIndex, setDisplayKeyIndex] = useState(-1);
@@ -375,6 +375,7 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
                                     locked={locked}
                                     showRawValues={showRawValues}
                                     recordSchema={recordSchema || {}}
+                                    insertField={insertField}
                                 />
                             }
                         </Box>

--- a/src/components/DocumentContainer/DocumentContainer.tsx
+++ b/src/components/DocumentContainer/DocumentContainer.tsx
@@ -4,7 +4,6 @@ import { Grid, Box, IconButton, Alert, Tooltip } from '@mui/material';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
 import ZoomInIcon from '@mui/icons-material/ZoomIn';
-import ZoomOutIcon from '@mui/icons-material/ZoomOut';
 import { ImageCropper } from '../ImageCropper/ImageCropper';
 import { useKeyDown } from '../../util';
 import AttributesTable from '../RecordAttributesTable/RecordAttributesTable';

--- a/src/components/DocumentContainer/DocumentContainer.tsx
+++ b/src/components/DocumentContainer/DocumentContainer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from "react-router-dom";
 import { Grid, Box, IconButton, Alert, Tooltip } from '@mui/material';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
@@ -11,7 +11,7 @@ import { DocumentContainerProps } from '../../types';
 import { DocumentContainerStyles as styles } from '../../styles';
 import Switch from '@mui/material/Switch';
 
-const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, handleUpdateRecord, locked, recordSchema, insertField, forceEditMode }: DocumentContainerProps) => {
+const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, locked, recordSchema, insertField, forceEditMode, handleSuccessfulAttributeUpdate, handleFailedUpdate }: DocumentContainerProps) => {
     const [imgIndex, setImgIndex] = useState(0);
     const [displayPoints, setDisplayPoints] = useState<number[][] | null>(null);
     const [displayKeyIndex, setDisplayKeyIndex] = useState(-1);
@@ -244,7 +244,7 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
     useKeyDown("ArrowUp", shiftTabCallback);
     useKeyDown("ArrowDown", tabCallback);
 
-    const handleClickField = (key: string, normalized_vertices: number[][] | null, primaryIndex: number, isSubattribute: boolean, subattributeIdx: number | null) => {
+    const handleClickField = React.useCallback((key: string, normalized_vertices: number[][] | null, primaryIndex: number, isSubattribute: boolean, subattributeIdx: number | null) => {
         if (!key || (!isSubattribute && primaryIndex === displayKeyIndex) || (isSubattribute && primaryIndex === displayKeyIndex && subattributeIdx === displayKeySubattributeIndex)) {
             setDisplayPoints(null);
             setDisplayKeyIndex(-1);
@@ -273,7 +273,7 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
                 setDisplayPoints(null);
             }
         }
-    }
+    }, [])
 
     const scrollToAttribute = (boxId: string, heightId: string, top: number) => {
         try{
@@ -371,12 +371,14 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, hand
                                     forceOpenSubtable={forceOpenSubtable}
                                     displayKeyIndex={displayKeyIndex}
                                     displayKeySubattributeIndex={displayKeySubattributeIndex}
-                                    handleUpdateRecord={() => handleUpdateRecord(autoCleanFields)}
+                                    // handleUpdateRecord={() => handleUpdateRecord(autoCleanFields)}
                                     locked={locked}
                                     showRawValues={showRawValues}
                                     recordSchema={recordSchema || {}}
                                     insertField={insertField}
                                     forceEditMode={forceEditMode}
+                                    handleSuccessfulAttributeUpdate={handleSuccessfulAttributeUpdate}
+                                    handleFailedUpdate={handleFailedUpdate}
                                 />
                             }
                         </Box>

--- a/src/components/DocumentContainer/DocumentContainer.tsx
+++ b/src/components/DocumentContainer/DocumentContainer.tsx
@@ -11,7 +11,8 @@ import { DocumentContainerProps } from '../../types';
 import { DocumentContainerStyles as styles } from '../../styles';
 import Switch from '@mui/material/Switch';
 
-const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, locked, recordSchema, insertField, forceEditMode, handleSuccessfulAttributeUpdate, handleFailedUpdate }: DocumentContainerProps) => {
+const DocumentContainer = ({ imageFiles, attributesList, ...attributeTableProps }: DocumentContainerProps) => {
+
     const [imgIndex, setImgIndex] = useState(0);
     const [displayPoints, setDisplayPoints] = useState<number[][] | null>(null);
     const [displayKeyIndex, setDisplayKeyIndex] = useState(-1);
@@ -273,7 +274,7 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, lock
                 setDisplayPoints(null);
             }
         }
-    }, [])
+    }, [imageFiles])
 
     const scrollToAttribute = (boxId: string, heightId: string, top: number) => {
         try{
@@ -366,18 +367,12 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, lock
                                 <AttributesTable 
                                     attributesList={attributesList}
                                     handleClickField={handleClickField}
-                                    handleChangeValue={handleChangeValue}
                                     fullscreen={fullscreen}
                                     forceOpenSubtable={forceOpenSubtable}
                                     displayKeyIndex={displayKeyIndex}
                                     displayKeySubattributeIndex={displayKeySubattributeIndex}
-                                    locked={locked}
                                     showRawValues={showRawValues}
-                                    recordSchema={recordSchema || {}}
-                                    insertField={insertField}
-                                    forceEditMode={forceEditMode}
-                                    handleSuccessfulAttributeUpdate={handleSuccessfulAttributeUpdate}
-                                    handleFailedUpdate={handleFailedUpdate}
+                                    {...attributeTableProps}
                                 />
                             }
                         </Box>

--- a/src/components/DocumentContainer/DocumentContainer.tsx
+++ b/src/components/DocumentContainer/DocumentContainer.tsx
@@ -371,7 +371,6 @@ const DocumentContainer = ({ imageFiles, attributesList, handleChangeValue, lock
                                     forceOpenSubtable={forceOpenSubtable}
                                     displayKeyIndex={displayKeyIndex}
                                     displayKeySubattributeIndex={displayKeySubattributeIndex}
-                                    // handleUpdateRecord={() => handleUpdateRecord(autoCleanFields)}
                                     locked={locked}
                                     showRawValues={showRawValues}
                                     recordSchema={recordSchema || {}}

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -742,7 +742,7 @@ const SubattributeRow = React.memo((props: SubattributeRowProps) => {
     const handleClickDeleteField = () => {
         setShowActions(false);
         setMenuAnchor(null);
-        // deleteField(topLevelIdx, true, idx);
+        deleteField(topLevelIdx, true, idx);
     }
 
     return (

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import { Table, TableBody, TableCell, TableHead, TableRow, TableContainer } from '@mui/material';
+import React, { useState, useEffect, MouseEvent } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableRow, TableContainer, Menu, MenuItem } from '@mui/material';
 import { Box, TextField, Collapse, Typography, IconButton, Badge, Tooltip, Stack } from '@mui/material';
 import { formatConfidence, useKeyDown, useOutsideClick, formatAttributeValue, formatDateTime } from '../../util';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import InfoIcon from '@mui/icons-material/Info';
 import EditIcon from '@mui/icons-material/Edit';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { Attribute, RecordAttributesTableProps } from '../../types';
 import { styles } from '../../styles';
 
@@ -44,6 +45,7 @@ const AttributesTable = (props: AttributesTableProps) => {
                             <TableCell sx={styles.headerRow}>Raw Value</TableCell>
                         }
                         <TableCell sx={styles.headerRow} align='right'>Confidence</TableCell>
+                        <TableCell sx={styles.headerRow} align='right'></TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody ref={ref}>
@@ -93,7 +95,11 @@ const AttributeRow = (props: AttributeRowProps) => {
     const [ editMode, setEditMode ] = useState(false);
     const [ openSubtable, setOpenSubtable ] = useState(true);
     const [ isSelected, setIsSelected ] = useState(false);
-    const [ lastSavedValue, setLastSavedValue ] = useState(v.value)
+    const [ lastSavedValue, setLastSavedValue ] = useState(v.value);
+    const [ menuAnchor, setMenuAnchor ] = useState<null | HTMLElement>(null);
+    const [showActions, setShowActions] = useState(false);
+
+    const allowMultiple = recordSchema[k]?.occurrence?.toLowerCase().includes('multiple');
 
     useEffect(() => {
         if (idx === displayKeyIndex && (displayKeySubattributeIndex === null || displayKeySubattributeIndex === undefined)) setIsSelected(true);
@@ -187,6 +193,12 @@ const AttributeRow = (props: AttributeRowProps) => {
             if ((v.lastUpdated/1000) < v.last_cleaned) return true
         }
         return false
+    }
+
+    const handleShowActions = (event: MouseEvent<HTMLElement>) => {
+        event.stopPropagation();
+        setShowActions(!showActions);
+        setMenuAnchor(event.currentTarget);
     }
 
     return (
@@ -337,6 +349,21 @@ const AttributeRow = (props: AttributeRowProps) => {
                     </p>
                 }
             </TableCell>
+            <TableCell>{allowMultiple ? (
+                <IconButton size='small' onClick={handleShowActions}>
+                    <MoreVertIcon/>
+                </IconButton>
+            ) : null}</TableCell> 
+            <Menu
+                id="actions"
+                anchorEl={menuAnchor}
+                open={showActions}
+                onClose={() => setShowActions(false)}
+                onClick={(e) => e.stopPropagation()}
+            >
+                <MenuItem>Add another '{k}'</MenuItem>
+                <MenuItem>Delete this '{k}'</MenuItem>
+            </Menu>
         </TableRow>
         {
             v.subattributes &&

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -89,7 +89,8 @@ const AttributeRow = (props: AttributeRowProps) => {
         displayKeySubattributeIndex,
         locked,
         showRawValues,
-        recordSchema
+        recordSchema,
+        insertField
     } = childProps;
     
     const [ editMode, setEditMode ] = useState(false);
@@ -201,6 +202,12 @@ const AttributeRow = (props: AttributeRowProps) => {
         setMenuAnchor(event.currentTarget);
     }
 
+    const handleInsertField = () => {
+        setShowActions(false);
+        setMenuAnchor(null);
+        insertField(k, idx, false);
+    }
+
     return (
     <>
         <TableRow id={`${k}::${idx}`} sx={(isSelected && !v.subattributes) ? {backgroundColor: "#EDEDED"} : {}} onClick={handleClickInside}>
@@ -213,7 +220,6 @@ const AttributeRow = (props: AttributeRowProps) => {
                     <IconButton
                         aria-label="expand row"
                         size="small"
-                        // onClick={() => setOpenSubtable(!openSubtable)}
                         sx={styles.rowIconButton}
                     >
                         {openSubtable ? <KeyboardArrowUpIcon sx={styles.rowIcon}/> : <KeyboardArrowDownIcon sx={styles.rowIcon}/>}
@@ -361,7 +367,7 @@ const AttributeRow = (props: AttributeRowProps) => {
                 onClose={() => setShowActions(false)}
                 onClick={(e) => e.stopPropagation()}
             >
-                <MenuItem>Add another '{k}'</MenuItem>
+                <MenuItem onClick={handleInsertField}>Add another '{k}'</MenuItem>
                 <MenuItem>Delete this '{k}'</MenuItem>
             </Menu>
         </TableRow>

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -120,15 +120,6 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
         }
     }, [displayKeyIndex, displayKeySubattributeIndex]);
 
-    // useEffect(() => {
-    //     // if (k==='Formation') {
-    //     if (k==='Type_of_Logs') {
-    //         console.log('v changed for '+k)
-    //         console.log(v);
-    //     }
-
-    // }, [v]);
-
     const handleClickInside = (e: React.MouseEvent<HTMLTableRowElement>) => {
         if (v.subattributes) setOpenSubtable(!openSubtable)
         e.stopPropagation();
@@ -582,8 +573,6 @@ const SubattributeRow = React.memo((props: SubattributeRowProps) => {
     const allowMultiple = recordSchema[schemaKey]?.occurrence?.toLowerCase().includes('multiple');
 
     const handleSuccess = (resp: any) => {
-        console.log(`looking for: attributesList.${topLevelIdx}.subattributes.${idx}`);
-        console.log(resp)
         const newV = resp?.[`attributesList.${topLevelIdx}.subattributes.${idx}`];
         const data: any = {
             isSubattribute: false,
@@ -736,7 +725,7 @@ const SubattributeRow = React.memo((props: SubattributeRowProps) => {
     const handleClickInsertField = () => {
         setShowActions(false);
         setMenuAnchor(null);
-        insertField(k, topLevelIdx, true, idx);
+        insertField(k, topLevelIdx, true, idx, topLevelKey);
     }
 
     const handleClickDeleteField = () => {

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -97,9 +97,9 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
         recordSchema,
         insertField,
         forceEditMode,
-        handleFailedUpdate,
         handleSuccessfulAttributeUpdate,
-        record_id
+        record_id,
+        showError
     } = childProps;
 
     // console.log(`rendered ${k}`);
@@ -136,6 +136,14 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
             v: newV,
         }
         handleSuccessfulAttributeUpdate(data)
+    }
+
+    const handleFailedUpdate = (data: any, response_status?: number) => {
+        if (response_status === 403) {
+            showError(`${data}.`);
+        } else {
+            console.error(`error updating attribute ${k}: ${data}`);
+        }
     }
 
     const handleUpdateRecord = (cleanFields: boolean = true) => {
@@ -251,13 +259,13 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
         return false
     }
 
-    const handleShowActions = (event: MouseEvent<HTMLElement>) => {
+    const handleClickShowActions = (event: MouseEvent<HTMLElement>) => {
         event.stopPropagation();
         setShowActions(!showActions);
         setMenuAnchor(event.currentTarget);
     }
 
-    const handleInsertField = () => {
+    const handleClickInsertField = () => {
         setShowActions(false);
         setMenuAnchor(null);
         insertField(k, idx, false);
@@ -427,7 +435,7 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
                 }
             </TableCell>
             <TableCell>{allowMultiple ? (
-                <IconButton size='small' onClick={handleShowActions}>
+                <IconButton size='small' onClick={handleClickShowActions}>
                     <MoreVertIcon/>
                 </IconButton>
             ) : null}</TableCell> 
@@ -438,7 +446,7 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
                 onClose={() => setShowActions(false)}
                 onClick={(e) => e.stopPropagation()}
             >
-                <MenuItem onClick={handleInsertField}>Add another '{k}'</MenuItem>
+                <MenuItem onClick={handleClickInsertField}>Add another '{k}'</MenuItem>
                 <MenuItem>Delete this '{k}'</MenuItem>
             </Menu>
         </TableRow>
@@ -539,7 +547,7 @@ const SubattributeRow = (props: SubattributeRowProps) => {
         showRawValues,
         recordSchema,
         topLevelKey,
-        handleFailedUpdate,
+        showError,
         handleSuccessfulAttributeUpdate,
         record_id
     } = props;
@@ -557,6 +565,14 @@ const SubattributeRow = (props: SubattributeRowProps) => {
             v: v
         }
         handleSuccessfulAttributeUpdate(data)
+    }
+
+    const handleFailedUpdate = (data: any, response_status?: number) => {
+        if (response_status === 403) {
+            showError(`${data}.`);
+        } else {
+            console.error(`error updating attribute ${k}: ${data}`);
+        }
     }
 
     const handleUpdateRecord = (cleanFields: boolean = true) => {

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -102,8 +102,6 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
         showError,
         deleteField
     } = childProps;
-
-    // console.log(`rendered ${k}`);
     
     const [ editMode, setEditMode ] = useState(false);
     const [ openSubtable, setOpenSubtable ] = useState(true);
@@ -123,7 +121,7 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
     }, [displayKeyIndex, displayKeySubattributeIndex]);
 
     useEffect(() => {
-        console.log('v changed for '+k)
+        if (k==='Formation') console.log('v changed for '+k)
     }, [v]);
 
     const handleClickInside = (e: React.MouseEvent<HTMLTableRowElement>) => {

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -312,6 +312,22 @@ const AttributeRow = (props: AttributeRowProps) => {
             }
             <TableCell align="right" id={v.key+'_confidence'}>
                 {
+                    v.user_added ? (
+                        <Tooltip title={(v.lastUpdated) ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy || 'unknown'}` : ''}>
+                            <p style={{padding:0, margin:0}}>
+                                <Badge
+                                    variant="dot"
+                                    sx={{
+                                    "& .MuiBadge-badge": {
+                                        color: "#2196F3",
+                                        backgroundColor: "#2196F3"
+                                    }
+                                    }}
+                                /> 
+                                &nbsp; Added
+                            </p> 
+                        </Tooltip>
+                    ) :
                     v.edited ? 
                     (
                         <Tooltip title={(v.lastUpdated) ? `Last updated ${formatDateTime(v.lastUpdated)} by ${v.lastUpdatedBy || 'unknown'}` : ''}>

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -120,9 +120,14 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
         }
     }, [displayKeyIndex, displayKeySubattributeIndex]);
 
-    useEffect(() => {
-        if (k==='Formation') console.log('v changed for '+k)
-    }, [v]);
+    // useEffect(() => {
+    //     // if (k==='Formation') {
+    //     if (k==='Type_of_Logs') {
+    //         console.log('v changed for '+k)
+    //         console.log(v);
+    //     }
+
+    // }, [v]);
 
     const handleClickInside = (e: React.MouseEvent<HTMLTableRowElement>) => {
         if (v.subattributes) setOpenSubtable(!openSubtable)
@@ -157,12 +162,12 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
             fieldToClean: any;
           } = { data: { key: k, idx: idx, v: v}, type: "attribute", fieldToClean: null }
         if (cleanFields) {
-            const lastUpdatedField = {
+            const fieldToClean = {
                 topLevelIndex: idx,
                 isSubattribute: false,
                 subIndex: null
             }
-            body['fieldToClean'] = lastUpdatedField
+            body['fieldToClean'] = fieldToClean;
         }
         callAPI(
             updateRecord,
@@ -545,7 +550,7 @@ interface SubattributeRowProps extends RecordAttributesTableProps {
     record_id?: string;
 }
 
-const SubattributeRow = (props: SubattributeRowProps) => { 
+const SubattributeRow = React.memo((props: SubattributeRowProps) => {
     const { 
         k, 
         v,
@@ -576,12 +581,15 @@ const SubattributeRow = (props: SubattributeRowProps) => {
     const schemaKey = `${topLevelKey}::${k}`
     const allowMultiple = recordSchema[schemaKey]?.occurrence?.toLowerCase().includes('multiple');
 
-    const handleSuccess = () => {
+    const handleSuccess = (resp: any) => {
+        console.log(`looking for: attributesList.${topLevelIdx}.subattributes.${idx}`);
+        console.log(resp)
+        const newV = resp?.[`attributesList.${topLevelIdx}.subattributes.${idx}`];
         const data: any = {
             isSubattribute: false,
             topLevelIndex: idx,
             subIndex: null,
-            v: v
+            v: newV,
         }
         handleSuccessfulAttributeUpdate(data)
     }
@@ -603,11 +611,18 @@ const SubattributeRow = (props: SubattributeRowProps) => {
     const handleUpdateRecord = (cleanFields: boolean = true) => {
         if (locked) return
         const body: {
-            data: { key: string; idx: number; v: any; isSubattribute: boolean; subindex: number; };
+            data: { key: string; idx: number; v: any, isSubattribute?: boolean, subIndex?: number };
             type: "attribute";
-            fieldToClean: string | null;
-          } = { data: { key: k, idx: topLevelIdx, v: v, isSubattribute: true, subindex: idx}, type: "attribute", fieldToClean: null }
-        if (cleanFields) body['fieldToClean'] = k;
+            fieldToClean: any;
+          } = { data: { key: k, idx: topLevelIdx, v: v, isSubattribute: true, subIndex: idx}, type: "attribute", fieldToClean: null }
+        if (cleanFields) {
+            const fieldToClean = {
+                topLevelIndex: topLevelIdx,
+                isSubattribute: true,
+                subIndex: idx
+            }
+            body['fieldToClean'] = fieldToClean
+        }
         callAPI(
             updateRecord,
             [record_id, body],
@@ -838,6 +853,6 @@ const SubattributeRow = (props: SubattributeRowProps) => {
             </Menu>
         </TableRow>
     )
-}
+})
 
 export default AttributesTable;

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -233,7 +233,7 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
     const finishEditing = () => {
         if (v.value !== lastSavedValue) {
             handleUpdateRecord();
-            setLastSavedValue(v.value)
+            setLastSavedValue(v.value);
         }
         setEditMode(false);
     }
@@ -251,9 +251,8 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
     }
 
     const showEditedValue = () => {
-        if (v.cleaned && v.edited && v.lastUpdated && v.last_cleaned) {
-            // only show if it's been cleaned since last update
-            if ((v.lastUpdated/1000) < v.last_cleaned) return true
+        if (v.edited && v.uncleaned_value) {
+            return true
         }
         return false
     }

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -90,7 +90,8 @@ const AttributeRow = (props: AttributeRowProps) => {
         locked,
         showRawValues,
         recordSchema,
-        insertField
+        insertField,
+        forceEditMode,
     } = childProps;
     
     const [ editMode, setEditMode ] = useState(false);
@@ -144,6 +145,10 @@ const AttributeRow = (props: AttributeRowProps) => {
     useEffect(() => {
         if (forceOpenSubtable === idx) setOpenSubtable(true);
     }, [forceOpenSubtable]);
+
+    useEffect(() => {
+        if (forceEditMode === idx) makeEditable();
+    }, [forceEditMode]);
 
     const handleDoubleClick = () => {
         makeEditable()

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom";
 import { Table, TableBody, TableCell, TableHead, TableRow, TableContainer, Menu, MenuItem } from '@mui/material';
 import { Box, TextField, Collapse, Typography, IconButton, Badge, Tooltip, Stack } from '@mui/material';
 
-import { updateRecord, cleanRecords } from '../../services/app.service';
+import { updateRecord } from '../../services/app.service';
 import { formatConfidence, useKeyDown, useOutsideClick, formatAttributeValue, formatDateTime, callAPI } from '../../util';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
@@ -534,7 +534,6 @@ const SubattributeRow = (props: SubattributeRowProps) => {
         topLevelIdx,
         displayKeyIndex,
         displayKeySubattributeIndex,
-        // handleUpdateRecord,
         idx,
         locked,
         showRawValues,

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -147,7 +147,13 @@ const AttributeRow = (props: AttributeRowProps) => {
     }, [forceOpenSubtable]);
 
     useEffect(() => {
-        if (forceEditMode === idx) makeEditable();
+        if (forceEditMode === idx) {
+            makeEditable();
+            setIsSelected(true);
+        } else if (forceEditMode !== undefined) {
+            finishEditing();
+            setIsSelected(false);
+        }
     }, [forceEditMode]);
 
     const handleDoubleClick = () => {

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -99,7 +99,8 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
         forceEditMode,
         handleSuccessfulAttributeUpdate,
         record_id,
-        showError
+        showError,
+        deleteField
     } = childProps;
 
     // console.log(`rendered ${k}`);
@@ -269,6 +270,12 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
         setShowActions(false);
         setMenuAnchor(null);
         insertField(k, idx, false);
+    }
+
+    const handleClickDeleteField = () => {
+        setShowActions(false);
+        setMenuAnchor(null);
+        deleteField(idx, false);
     }
 
     return (
@@ -447,7 +454,9 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
                 onClick={(e) => e.stopPropagation()}
             >
                 <MenuItem onClick={handleClickInsertField}>Add another '{k}'</MenuItem>
-                <MenuItem>Delete this '{k}'</MenuItem>
+                {v.user_added && 
+                    <MenuItem onClick={handleClickDeleteField}>Delete this '{k}'</MenuItem>
+                }
             </Menu>
         </TableRow>
         {

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -211,8 +211,8 @@ const AttributeRow = React.memo((props: AttributeRowProps) => {
             makeEditable();
             handleClickField(k, v.normalized_vertices, idx, false, null);
         } else if (forceEditMode[0] !== -1) {
-            finishEditing();
             setIsSelected(false);
+            setEditMode(false);
         }
     }, [forceEditMode]);
 

--- a/src/components/RecordAttributesTable/RecordAttributesTable.tsx
+++ b/src/components/RecordAttributesTable/RecordAttributesTable.tsx
@@ -292,7 +292,7 @@ const AttributeRow = (props: AttributeRowProps) => {
                                     </Typography>
                                 }
                                 {
-                                    (v.cleaned || v.cleaning_error) &&
+                                    (v.cleaned || v.cleaning_error) && (!v.user_added) &&
                                     <Typography noWrap component={'p'} sx={styles.ocrRawText} onClick={(e) => e.stopPropagation()}>
                                         OCR Raw Value: {v.raw_text}
                                     </Typography>

--- a/src/components/Subheader/Subheader.tsx
+++ b/src/components/Subheader/Subheader.tsx
@@ -1,4 +1,4 @@
-import { useState, Fragment, MouseEvent, useEffect } from 'react';
+import { useState, Fragment, MouseEvent } from 'react';
 import { useNavigate } from "react-router-dom";
 import { Button, Grid, IconButton, Box, Menu, MenuItem, Chip } from '@mui/material';
 import HomeIcon from '@mui/icons-material/Home';

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,7 +167,7 @@ export interface RecordAttributesTableProps {
     locked?: boolean;
     showRawValues?: boolean;
     recordSchema: RecordSchema;
-    forceEditMode?: number;
+    forceEditMode: number[];
     insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
     handleSuccessfulAttributeUpdate: (data: any) => void;
     showError: (errorMessage: string) => void;
@@ -259,7 +259,7 @@ export interface DocumentContainerProps {
     handleChangeValue: handleChangeValueSignature;
     locked?: boolean;
     recordSchema: RecordSchema;
-    forceEditMode?: number;
+    forceEditMode: number[];
     insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
     handleSuccessfulAttributeUpdate: (data: any) => void;
     showError: (errorMessage: string) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,12 +164,14 @@ export interface RecordAttributesTableProps {
     fullscreen: string | null;
     displayKeyIndex: number;
     displayKeySubattributeIndex: number | null;
-    handleUpdateRecord: (...args: any[]) => void;
+    // handleUpdateRecord: (...args: any[]) => void;
     locked?: boolean;
     showRawValues?: boolean;
     recordSchema: RecordSchema;
     forceEditMode?: number;
     insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
+    handleSuccessfulAttributeUpdate: (data: any) => void;
+    handleFailedUpdate: (data: any, response_status?: number) => void;
 }
 
 export interface RecordsTableProps {
@@ -255,11 +257,13 @@ export interface DocumentContainerProps {
     imageFiles: string[];
     attributesList: any[];
     handleChangeValue: handleChangeValueSignature;
-    handleUpdateRecord: (...args: any[]) => void;
+    // handleUpdateRecord: (...args: any[]) => void;
     locked?: boolean;
     recordSchema: RecordSchema;
     forceEditMode?: number;
     insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
+    handleSuccessfulAttributeUpdate: (data: any) => void;
+    handleFailedUpdate: (data: any, response_status?: number) => void;
 }
 
 export interface ColumnSelectDialogProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export interface Attribute {
     lastUpdatedBy?: string;
     last_cleaned?: number; // timestamp in seconds
     user_added?: boolean;
+    topLevelAttribute?: string;
 }
 
 export interface Processor {
@@ -168,7 +169,7 @@ export interface RecordAttributesTableProps {
     showRawValues?: boolean;
     recordSchema: RecordSchema;
     forceEditMode: number[];
-    insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
+    insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number, parentAttribute?: string) => void;
     handleSuccessfulAttributeUpdate: (data: any) => void;
     showError: (errorMessage: string) => void;
     deleteField: (topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => void;
@@ -260,7 +261,7 @@ export interface DocumentContainerProps {
     locked?: boolean;
     recordSchema: RecordSchema;
     forceEditMode: number[];
-    insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
+    insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number, parentAttribute?: string) => void;
     handleSuccessfulAttributeUpdate: (data: any) => void;
     showError: (errorMessage: string) => void;
     deleteField: (topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,7 +164,6 @@ export interface RecordAttributesTableProps {
     fullscreen: string | null;
     displayKeyIndex: number;
     displayKeySubattributeIndex: number | null;
-    // handleUpdateRecord: (...args: any[]) => void;
     locked?: boolean;
     showRawValues?: boolean;
     recordSchema: RecordSchema;
@@ -257,7 +256,6 @@ export interface DocumentContainerProps {
     imageFiles: string[];
     attributesList: any[];
     handleChangeValue: handleChangeValueSignature;
-    // handleUpdateRecord: (...args: any[]) => void;
     locked?: boolean;
     recordSchema: RecordSchema;
     forceEditMode?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,7 +170,7 @@ export interface RecordAttributesTableProps {
     forceEditMode?: number;
     insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
     handleSuccessfulAttributeUpdate: (data: any) => void;
-    handleFailedUpdate: (data: any, response_status?: number) => void;
+    showError: (errorMessage: string) => void;
 }
 
 export interface RecordsTableProps {
@@ -261,7 +261,7 @@ export interface DocumentContainerProps {
     forceEditMode?: number;
     insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
     handleSuccessfulAttributeUpdate: (data: any) => void;
-    handleFailedUpdate: (data: any, response_status?: number) => void;
+    showError: (errorMessage: string) => void;
 }
 
 export interface ColumnSelectDialogProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,7 @@ export interface Attribute {
     lastUpdated?: number; // timestamp in milliseconds
     lastUpdatedBy?: string;
     last_cleaned?: number; // timestamp in seconds
+    user_added?: boolean;
 }
 
 export interface Processor {
@@ -167,6 +168,7 @@ export interface RecordAttributesTableProps {
     locked?: boolean;
     showRawValues?: boolean;
     recordSchema: RecordSchema;
+    insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
 }
 
 export interface RecordsTableProps {
@@ -255,6 +257,7 @@ export interface DocumentContainerProps {
     handleUpdateRecord: (...args: any[]) => void;
     locked?: boolean;
     recordSchema: RecordSchema;
+    insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
 }
 
 export interface ColumnSelectDialogProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,7 @@ export interface RecordAttributesTableProps {
     locked?: boolean;
     showRawValues?: boolean;
     recordSchema: RecordSchema;
+    forceEditMode?: number;
     insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
 }
 
@@ -257,6 +258,7 @@ export interface DocumentContainerProps {
     handleUpdateRecord: (...args: any[]) => void;
     locked?: boolean;
     recordSchema: RecordSchema;
+    forceEditMode?: number;
     insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,7 @@ export interface RecordAttributesTableProps {
     insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
     handleSuccessfulAttributeUpdate: (data: any) => void;
     showError: (errorMessage: string) => void;
+    deleteField: (topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => void;
 }
 
 export interface RecordsTableProps {
@@ -262,6 +263,7 @@ export interface DocumentContainerProps {
     insertField: (k: string, topLevelIndex: number, isSubattribute: boolean, subIndex?: number) => void;
     handleSuccessfulAttributeUpdate: (data: any) => void;
     showError: (errorMessage: string) => void;
+    deleteField: (topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => void;
 }
 
 export interface ColumnSelectDialogProps {

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Box } from '@mui/material';
-import { useParams, useNavigate, redirect } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { getRecordData, updateRecord, deleteRecord, cleanRecords } from '../../services/app.service';
 import { callAPI, useKeyDown } from '../../util';
 import Subheader from '../../components/Subheader/Subheader';
@@ -151,6 +151,39 @@ const Record = () => {
             console.error('error updating record data: ', data);
         }
     }
+
+    const insertField = (k: string, topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => {
+        // console.log(`inserting ${k} at index ${topLevelIndex}${isSubattribute ? ":"+subIndex : ''}`);
+        let tempRecordData = { ...recordData };
+        let tempAttributesList = [...tempRecordData.attributesList];
+        // let rightNow = Date.now();
+        let newField = {
+            "key": k,
+            "ai_confidence": null,
+            "confidence": null,
+            "raw_text": null,
+            "text_value": null,
+            "value": "",
+            "normalized_vertices": null,
+            "normalized_value": null,
+            "subattributes": null,
+            "isSubattribute": false,
+            "edited": false,
+            "page": null,
+        }
+        if (isSubattribute) {
+            // TODO: handle subattribute
+            console.log("subattribute, returning");
+            return;
+        } else {
+            tempAttributesList.splice(topLevelIndex+1, 0, newField);
+        }
+        // TODO: make this new field be in edit mode (might have to be done in RecordAttributesTable component)
+        tempRecordData.attributesList = tempAttributesList;
+        setRecordData(tempRecordData);
+    }
+
+
 
     const handleChangeValue: handleChangeValueSignature = (event, topLevelIndex, isSubattribute, subIndex) => {
         if (locked) return true
@@ -314,6 +347,7 @@ const Record = () => {
                     handleUpdateRecord={handleUpdateRecord}
                     locked={locked}
                     recordSchema={recordSchema || {}}
+                    insertField={insertField}
                 />
             </Box>
             <Bottombar

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -162,7 +162,6 @@ const Record = () => {
 
     const insertField = React.useCallback((k: string, topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => {
         if (isSubattribute && subIndex !== undefined) {
-            console.log("subattribute");
             const newSubIndex = subIndex + 1;
             const newSubField = {
                 "key": k,
@@ -206,6 +205,7 @@ const Record = () => {
                     }
                 });
                 const newRecordData = { ...tempRecordData, attributesList: newAttributesList };
+                handleUpdateRecord(newRecordData);
                 return newRecordData;
             })
             setTimeout(() => {
@@ -231,14 +231,18 @@ const Record = () => {
                 "page": null,
                 "user_added": true,
             }
-            setRecordData(tempRecordData => ({
-                ...tempRecordData,
-                attributesList: [
-                    ...tempRecordData.attributesList.slice(0, newIndex),
-                    newField,
-                    ...tempRecordData.attributesList.slice(newIndex),
-                ]
-            }))
+            setRecordData(tempRecordData => {
+                const newRecordData = {
+                    ...tempRecordData,
+                    attributesList: [
+                        ...tempRecordData.attributesList.slice(0, newIndex),
+                        newField,
+                        ...tempRecordData.attributesList.slice(newIndex),
+                    ]
+                }
+                handleUpdateRecord(newRecordData);
+                return newRecordData;
+            })
             // force new field to be in edit mode (open text field)
             // is there a better way to do this?
             setTimeout(() => {

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -140,13 +140,7 @@ const Record = () => {
     const handleSuccessfulAttributeUpdate = React.useCallback((data: any) => {
         // TODO: dont just update value; update entire v
         const { isSubattribute, topLevelIndex, subIndex, v } = data;
-        const value = v.value;
-        let fakeEvent = {
-            target: {
-                value: value
-            }
-        } as React.ChangeEvent<HTMLInputElement>
-        handleChangeValue(fakeEvent, topLevelIndex, isSubattribute, subIndex)
+        handleChangeAttribute(v, topLevelIndex, isSubattribute, subIndex)
     }, [])
 
     const handleFailedUpdate = (data: any, response_status?: number) => {
@@ -272,6 +266,68 @@ const Record = () => {
             return newRecordData;
         })
     }, [])
+
+    const handleChangeAttribute = (newAttribute: Attribute, topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => {
+        if (locked) return true
+        // const rightNow = Date.now();
+
+        const newValue = newAttribute.value;
+        const newNormalizedValue = newAttribute.normalized_value;
+        const new_uncleaned_value = newAttribute.uncleaned_value;
+        const new_cleaned = newAttribute.cleaned;
+        const new_cleaning_error = newAttribute.cleaning_error;
+        const new_edited = newAttribute.edited;
+        const new_lastUpdated = newAttribute.lastUpdated;
+        const new_lastUpdatedBy = newAttribute.lastUpdatedBy;
+        const new_last_cleaned = newAttribute.last_cleaned;
+
+        if (!isSubattribute) {
+            setRecordData(tempRecordData => ({
+                ...tempRecordData,
+                attributesList: tempRecordData.attributesList.map((tempAttribute, idx) =>
+                    topLevelIndex === idx ? { 
+                        ...tempAttribute, 
+                        value: newValue,
+                        normalized_value: newNormalizedValue,
+                        cleaned: new_cleaned,
+                        cleaning_error: new_cleaning_error,
+                        uncleaned_value: new_uncleaned_value,
+                        edited: new_edited,
+                        lastUpdated: new_lastUpdated,
+                        lastUpdatedBy: new_lastUpdatedBy,
+                        last_cleaned: new_last_cleaned,
+                        // user_added: new_user_added,
+                    } : tempAttribute
+                )
+            }))
+        } else {
+            setRecordData(tempRecordData => ({
+                ...tempRecordData,
+                attributesList: tempRecordData.attributesList.map((tempAttribute, idx) =>
+                    topLevelIndex === idx ? { 
+                        ...tempAttribute,
+                        subattributes: tempAttribute.subattributes.map((tempSubattribute: Attribute, subidx: number) => {
+                            if (subIndex === subidx) {
+                                return {
+                                    ...tempSubattribute,
+                                    value: newValue,
+                                    normalized_value: newNormalizedValue,
+                                    cleaned: new_cleaned,
+                                    cleaning_error: new_cleaning_error,
+                                    uncleaned_value: new_uncleaned_value,
+                                    edited: new_edited,
+                                    lastUpdated: new_lastUpdated,
+                                    lastUpdatedBy: new_lastUpdatedBy,
+                                    last_cleaned: new_last_cleaned,
+                                }
+                            } else return tempSubattribute
+                            }
+                        )
+                    } : tempAttribute
+                )
+            }))
+        }
+    }
 
     const handleChangeValue: handleChangeValueSignature = React.useCallback((event, topLevelIndex, isSubattribute, subIndex) => {
         if (locked) return true

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -113,6 +113,17 @@ const Record = () => {
         setRecordName(event.target.value);
     }
 
+    const handleUpdateRecord = (newRecordData: RecordData) => {
+        if (locked) return
+        let body = { data: newRecordData, type: "attributesList" }
+        callAPI(
+            updateRecord,
+            [params.id, body],
+            handleSuccessfulDeletion,
+            handleFailedUpdate
+        );
+    }
+
     const handleUpdateRecordName = () => {
         if (locked) return
         setOpenUpdateNameModal(false);
@@ -123,6 +134,8 @@ const Record = () => {
             handleFailedUpdate
         );
     }
+
+    const handleSuccessfulDeletion = (data: any) => {}
 
     const handleSuccessfulAttributeUpdate = React.useCallback((data: any) => {
         const { isSubattribute, topLevelIndex, subIndex, v } = data;
@@ -188,6 +201,23 @@ const Record = () => {
                 setForceEditMode(undefined);
             }, 0)
         }, 0)
+    }, [])
+
+    const deleteField = React.useCallback((topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => {
+        if (isSubattribute) {
+            // TODO: handle subattribute
+            // we will need to call setRecordData differently
+            console.log("subattribute, returning");
+            return;
+        }
+        setRecordData(tempRecordData => {
+            const newRecordData = {
+                ...tempRecordData,
+                attributesList: tempRecordData.attributesList.filter((_, i) => i !== topLevelIndex),
+            }
+            handleUpdateRecord(newRecordData);
+            return newRecordData;
+        })
     }, [])
 
     const handleChangeValue: handleChangeValueSignature = React.useCallback((event, topLevelIndex, isSubattribute, subIndex) => {
@@ -356,6 +386,7 @@ const Record = () => {
                     locked={locked}
                     recordSchema={recordSchema || {}}
                     insertField={insertField}
+                    deleteField={deleteField}
                     forceEditMode={forceEditMode}
                     handleSuccessfulAttributeUpdate={handleSuccessfulAttributeUpdate}
                     showError={showError}

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -138,6 +138,7 @@ const Record = () => {
     const handleSuccessfulDeletion = (data: any) => {}
 
     const handleSuccessfulAttributeUpdate = React.useCallback((data: any) => {
+        // TODO: dont just update value; update entire v
         const { isSubattribute, topLevelIndex, subIndex, v } = data;
         const value = v.value;
         let fakeEvent = {
@@ -302,14 +303,17 @@ const Record = () => {
                         edited: true,
                         lastUpdated: rightNow,
                         lastUpdatedBy: userEmail,
-                        subAttributes: tempAttribute.subattributes.map((tempSubattribute: Attribute, subidx: number) => 
-                            subIndex === subidx ? {
-                                ...tempSubattribute,
-                                value: value,
-                                edited: true,
-                                lastUpdated: rightNow,
-                                lastUpdatedBy: userEmail,
-                            } : tempSubattribute
+                        subattributes: tempAttribute.subattributes.map((tempSubattribute: Attribute, subidx: number) => {
+                                if (subIndex === subidx) {
+                                    return {
+                                        ...tempSubattribute,
+                                        value: value,
+                                        edited: true,
+                                        lastUpdated: rightNow,
+                                        lastUpdatedBy: userEmail,
+                                    }
+                                } else return tempSubattribute
+                            }
                         )
                     } : tempAttribute
                 )

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -154,7 +154,7 @@ const Record = () => {
         setErrorMsg(errorMessage);
     }, [])
 
-    const insertField = React.useCallback((k: string, topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => {
+    const insertField = React.useCallback((k: string, topLevelIndex: number, isSubattribute?: boolean, subIndex?: number, parentAttribute?: string) => {
         if (isSubattribute && subIndex !== undefined) {
             const newSubIndex = subIndex + 1;
             const newSubField = {
@@ -171,6 +171,7 @@ const Record = () => {
                 "edited": false,
                 "page": null,
                 "user_added": true,
+                "topLevelAttribute": parentAttribute,
             }
             setRecordData(tempRecordData => {
                 const newAttributesList = tempRecordData.attributesList.map((attribute, i) => {
@@ -247,8 +248,6 @@ const Record = () => {
 
     const deleteField = React.useCallback((topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => {
         if (isSubattribute) {
-            // TODO: handle subattribute
-            console.log("subattribute");
             setRecordData(tempRecordData => {
                 const newAttributesList = tempRecordData.attributesList.map((attribute, idx) => {
                     if (idx !== topLevelIndex) return attribute;
@@ -288,6 +287,7 @@ const Record = () => {
         const new_lastUpdated = newAttribute.lastUpdated;
         const new_lastUpdatedBy = newAttribute.lastUpdatedBy;
         const new_last_cleaned = newAttribute.last_cleaned;
+        const topLevelAttribute = newAttribute.topLevelAttribute;
 
         if (!isSubattribute) {
             setRecordData(tempRecordData => ({
@@ -327,6 +327,7 @@ const Record = () => {
                                     lastUpdated: new_lastUpdated,
                                     lastUpdatedBy: new_lastUpdatedBy,
                                     last_cleaned: new_last_cleaned,
+                                    topLevelAttribute: topLevelAttribute,
                                 }
                             } else return tempSubattribute
                             }

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -20,7 +20,6 @@ const Record = () => {
     const [previousPages, setPreviousPages] = useState<PreviousPages>({ "Projects": () => navigate("/projects") });
     const [errorMsg, setErrorMsg] = useState<string | null>("");
     const [showResetPrompt, setShowResetPrompt] = useState(false);
-    const [ lastUpdatedField, setLastUpdatedField ] = useState<any>()
     const [ subheaderActions, setSubheaderActions ] = useState<SubheaderActions>()
     const [ recordSchema, setRecordSchema ] = useState<RecordSchema>()
     const [ forceEditMode, setForceEditMode ] = useState<number>()
@@ -126,7 +125,6 @@ const Record = () => {
     }
 
     const handleSuccessfulAttributeUpdate = React.useCallback((data: any) => {
-        setLastUpdatedField(undefined)
         const { isSubattribute, topLevelIndex, subIndex, v } = data;
         const value = v.value;
         let fakeEvent = {
@@ -164,6 +162,7 @@ const Record = () => {
         }
         if (isSubattribute) {
             // TODO: handle subattribute
+            // we will need to call setRecordData differently
             console.log("subattribute, returning");
             return;
         }
@@ -178,6 +177,7 @@ const Record = () => {
         }))
         
         // force new field to be in edit mode (open text field)
+        // is there a better way to do this?
         setTimeout(() => {
             setForceEditMode(newIndex);
             setTimeout(() => {
@@ -185,8 +185,6 @@ const Record = () => {
             }, 0)
         }, 0)
     }, [])
-
-
 
     const handleChangeValue: handleChangeValueSignature = React.useCallback((event, topLevelIndex, isSubattribute, subIndex) => {
         if (locked) return true
@@ -231,12 +229,6 @@ const Record = () => {
                 )
             }))
         }
-        const tempLastUpdatedField = {
-            topLevelIndex: topLevelIndex,
-            'isSubattribute': isSubattribute,
-            'subIndex': subIndex
-        }
-        setLastUpdatedField(tempLastUpdatedField)
     }, [])
 
     const handleDeleteRecord = () => {

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -135,12 +135,16 @@ const Record = () => {
         handleChangeValue(fakeEvent, topLevelIndex, isSubattribute, subIndex)
     }, [])
 
-    const handleFailedUpdate = React.useCallback((data: any, response_status?: number) => {
+    const handleFailedUpdate = (data: any, response_status?: number) => {
         if (response_status === 403) {
-            setErrorMsg(`${data}.`);
+            showError(`${data}.`);
         } else {
             console.error('error updating record data: ', data);
         }
+    }
+
+    const showError = React.useCallback((errorMessage: string) => {
+        setErrorMsg(errorMessage);
     }, [])
 
     const insertField = React.useCallback((k: string, topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => {
@@ -349,13 +353,12 @@ const Record = () => {
                     imageFiles={recordData.img_urls}
                     attributesList={recordData.attributesList}
                     handleChangeValue={handleChangeValue}
-                    // handleUpdateRecord={handleUpdateRecord}
                     locked={locked}
                     recordSchema={recordSchema || {}}
                     insertField={insertField}
                     forceEditMode={forceEditMode}
                     handleSuccessfulAttributeUpdate={handleSuccessfulAttributeUpdate}
-                    handleFailedUpdate={handleFailedUpdate}
+                    showError={showError}
                 />
             </Box>
             <Bottombar

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -23,6 +23,7 @@ const Record = () => {
     const [ lastUpdatedField, setLastUpdatedField ] = useState<any>()
     const [ subheaderActions, setSubheaderActions ] = useState<SubheaderActions>()
     const [ recordSchema, setRecordSchema ] = useState<RecordSchema>()
+    const [ forceEditMode, setForceEditMode ] = useState<number>()
     const [locked, setLocked] = useState(false)
     const params = useParams<{ id: string }>();
     const navigate = useNavigate();
@@ -154,10 +155,11 @@ const Record = () => {
 
     const insertField = (k: string, topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => {
         // console.log(`inserting ${k} at index ${topLevelIndex}${isSubattribute ? ":"+subIndex : ''}`);
-        let tempRecordData = { ...recordData };
-        let tempAttributesList = [...tempRecordData.attributesList];
+        const newIndex = topLevelIndex+1;
+        const tempRecordData = { ...recordData };
+        const tempAttributesList = [...tempRecordData.attributesList];
         // let rightNow = Date.now();
-        let newField = {
+        const newField = {
             "key": k,
             "ai_confidence": null,
             "confidence": null,
@@ -177,11 +179,14 @@ const Record = () => {
             console.log("subattribute, returning");
             return;
         } else {
-            tempAttributesList.splice(topLevelIndex+1, 0, newField);
+            tempAttributesList.splice(newIndex, 0, newField);
         }
         // TODO: make this new field be in edit mode (might have to be done in RecordAttributesTable component)
         tempRecordData.attributesList = tempAttributesList;
         setRecordData(tempRecordData);
+        setTimeout(() => {
+            setForceEditMode(newIndex)
+        }, 0)
     }
 
 
@@ -349,6 +354,7 @@ const Record = () => {
                     locked={locked}
                     recordSchema={recordSchema || {}}
                     insertField={insertField}
+                    forceEditMode={forceEditMode}
                 />
             </Box>
             <Bottombar

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -138,7 +138,6 @@ const Record = () => {
     const handleSuccessfulDeletion = (data: any) => {}
 
     const handleSuccessfulAttributeUpdate = React.useCallback((data: any) => {
-        // TODO: dont just update value; update entire v
         const { isSubattribute, topLevelIndex, subIndex, v } = data;
         handleChangeAttribute(v, topLevelIndex, isSubattribute, subIndex)
     }, [])
@@ -173,14 +172,11 @@ const Record = () => {
                 "page": null,
                 "user_added": true,
             }
-            // TODO: this seems to work, but it is not causing a re-render of the row
             setRecordData(tempRecordData => {
                 const newAttributesList = tempRecordData.attributesList.map((attribute, i) => {
-                    if (i !== topLevelIndex) return attribute;           // ♻️ keep reference for untouched rows
-              
-                    // 2️⃣ build the *new* inner array
+                    if (i !== topLevelIndex) return attribute;
+
                     const currentSubattributes = attribute.subattributes;
-                    console.log(currentSubattributes);
                     if (!attribute.subattributes) {
                         return {
                             ...attribute,
@@ -188,11 +184,10 @@ const Record = () => {
                         };
                     } else {
                         const newSubattributes = [
-                            ...currentSubattributes.slice(0, newSubIndex),   // everything before insertion point
-                            newSubField,                                 // the element we’re inserting
-                            ...currentSubattributes.slice(newSubIndex),      // everything after insertion point
+                            ...currentSubattributes.slice(0, newSubIndex),
+                            newSubField,
+                            ...currentSubattributes.slice(newSubIndex),
                           ];
-                          console.log(newSubattributes);
                           return {
                             ...attribute,
                             subattributes: newSubattributes,
@@ -253,18 +248,31 @@ const Record = () => {
     const deleteField = React.useCallback((topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => {
         if (isSubattribute) {
             // TODO: handle subattribute
-            // we will need to call setRecordData differently
-            console.log("subattribute, returning");
-            return;
+            console.log("subattribute");
+            setRecordData(tempRecordData => {
+                const newAttributesList = tempRecordData.attributesList.map((attribute, idx) => {
+                    if (idx !== topLevelIndex) return attribute;
+                    else {
+                        return {
+                            ...attribute,
+                            subattributes: attribute.subattributes.filter((_: any, subidx: number) => subidx !== subIndex)
+                        }
+                    }
+                });
+                const newRecordData = { ...tempRecordData, attributesList: newAttributesList };
+                handleUpdateRecord(newRecordData);
+                return newRecordData;
+            })
+        } else {
+            setRecordData(tempRecordData => {
+                const newRecordData = {
+                    ...tempRecordData,
+                    attributesList: tempRecordData.attributesList.filter((_, i) => i !== topLevelIndex),
+                }
+                handleUpdateRecord(newRecordData);
+                return newRecordData;
+            })
         }
-        setRecordData(tempRecordData => {
-            const newRecordData = {
-                ...tempRecordData,
-                attributesList: tempRecordData.attributesList.filter((_, i) => i !== topLevelIndex),
-            }
-            handleUpdateRecord(newRecordData);
-            return newRecordData;
-        })
     }, [])
 
     const handleChangeAttribute = (newAttribute: Attribute, topLevelIndex: number, isSubattribute?: boolean, subIndex?: number) => {

--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -170,6 +170,7 @@ const Record = () => {
             "isSubattribute": false,
             "edited": false,
             "page": null,
+            "user_added": true,
         }
         if (isSubattribute) {
             // TODO: handle subattribute


### PR DESCRIPTION
- relies on (server pr 121)[https://github.com/CATALOG-Historic-Records/orphaned-wells-ui-server/pull/121]
- add functionality to add new fields for fields that are of type multiple
- memoize functions and `AttributesRow` component to ensure it only re-renders when that row updates