### PR TITLE
fix bug on previous record keyboard shortcut

### DIFF
--- a/src/views/RecordPage/RecordPage.tsx
+++ b/src/views/RecordPage/RecordPage.tsx
@@ -420,7 +420,7 @@ const Record = () => {
         handleUpdateReviewStatus("reviewed")
     }
 
-    useKeyDown("ArrowLeft", undefined, undefined, handleClickPrevious, undefined, true);
+    useKeyDown("ArrowLeft", undefined, undefined, handleClickPrevious, undefined, false);
     useKeyDown("ArrowRight", undefined, undefined, handleClickNext, handleClickMarkReviewed, true);
 
     const navigateToRecord = (data: any) => {


### PR DESCRIPTION
- prevent default behavior when using command+left arrow (on mac, command+left arrow also performs "back" on web browser)