### PR TITLE
update documentation for prerequisites

### DIFF
--- a/docs/docs/deploy-gcp/add-collaborator.mdx
+++ b/docs/docs/deploy-gcp/add-collaborator.mdx
@@ -117,6 +117,10 @@ Use <CollaboratorInline /> for the short deployment key, such as `rrc`, `ca`, `i
 
 Some existing backend workflow fields are still named `DEPLOY_ENV`. In this checklist, their value should be the collaborator key unless the existing workflow has a documented exception.
 
+## 0. Prerequisites
+
+Refer to the Prerequisites section of the [Backend on GKE](./backend-gke) for details of prerequisite permissions/software needed.
+
 ## 1. Choose names
 
 Confirm the names before changing code:

--- a/docs/docs/deploy-gcp/backend-gke.mdx
+++ b/docs/docs/deploy-gcp/backend-gke.mdx
@@ -47,7 +47,9 @@ Required Google APIs:
 - Compute Engine API: `compute.googleapis.com`
 - Cloud DNS API: `dns.googleapis.com`
 
-The identity running Terraform needs permissions to manage GKE, Compute addresses, Cloud DNS, and project services if Terraform manages API enablement. The GitHub Actions service account in `SERVICE_KEY_JSON` needs enough access to fetch GKE credentials and apply Kubernetes resources.
+Other Required Tools:
+-ability to edit Github Secrets/Actions for OGRRE github project CATALOG-HISTORIC-RECORDS
+-permissions to manage GKE, Compute addresses, Cloud DNS, OAUTH and project services in gcloud
 
 ## Prepare deployment targets
 


### PR DESCRIPTION
Some small changes to the documentation for deploying a new OGRRE instance. Important part was I added link to prerequisites section of documentation for easier navigation.